### PR TITLE
Rename workflow from BamQC to bam_qc_metrics

### DIFF
--- a/workflow-bam-qc/pom.xml
+++ b/workflow-bam-qc/pom.xml
@@ -18,7 +18,7 @@
     <name>${display-name}</name>
 
     <properties>
-        <workflow-name>BamQC</workflow-name>
+        <workflow-name>bam_qc_metrics</workflow-name>
         <samtools-version>0.1.19</samtools-version>
         <bamqcmetrics-version>0.2.0</bamqcmetrics-version>
     </properties>


### PR DESCRIPTION
Rename workflow as suggested by @morgantaschuk, to avoid confusion with older BamQC releases.