### PR TITLE
Change module loading for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+## 5.0.2 - 2022-08-31
+- Modify python module loading during validation
 ## 5.0.1 - 2022-08-31
 - Update workflow name to `bamqc_call_ready_by_tumor_group` for clinical
 ## 5.0.0 - 2021-06-01

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -6,7 +6,7 @@ set -o pipefail
 cd $1
 
 module load jq
-# attempt to load different module versions in case of conflict
-module load python/3.9 || module load python/3.7 || module load python/3.6
+# load python only if it's not already loaded
+module is-loaded python || module load python/3.10.4
 # remove the Picard header because it includes temporary paths
 find . -xtype f -exec jq 'del(.picard | .header)' {} \; | python3 -mjson.tool --sort-keys


### PR DESCRIPTION
[Tests failed recently](https://gsici.hpc.oicr.on.ca/job/bamQC_vidarr/view/tags/job/5.0.1/) because python 3.10 was already loaded, so I'm hoping this will bypass the issue, but please do let me know if there's a better process.