### PR TITLE
bamQC lite variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+##  [5.3.0] - 2024-08-10
+### Changed
+- Converted into a faster bamQC lite variant.
+- [GRD-946](https://jira.oicr.on.ca/browse/GRD-946)
+
 ## [5.2.0] - 2024-06-25
 ### Added
 - Add vidarr labels to outputs (changes to medata only).

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # bamQC
 
-bamQC workflow collects a number of metrics which are computed using several methods (by employing third-party software tools along with some custom code) and outputs the results in JSON format. The output also contains metadata, such as the instrument and lane names. Also, it contains the estimate of ribosomal rRNA contamination and other information. bamQC supports downsampling for faster analysis and splits some tasks by chromosome, which also increases speed.
+bamQC workflow collects a number of metrics which are computed using several methods (by employing third-party software tools along with some custom code) and outputs the results in JSON format. The output also contains metadata, such as the instrument and lane names. bamQC supports downsampling for faster analysis.
 
 ## Overview
 
 ## Dependencies
 
-* [samtools 1.14](https://github.com/samtools/samtools)
-* [picard 2.21.2](https://broadinstitute.github.io/picard/command-line-overview.html)
+* [samtools 1.16.1](https://github.com/samtools/samtools)
+* [samblaster 0.1.26](https://github.com/GregoryFaust/samblaster)
 * [python 3.6](https://www.python.org/downloads/)
-* [bam-qc-metrics 0.2.5](https://github.com/oicr-gsi/bam-qc-metrics.git)
+* [bam-qc-metrics 0.2.6](https://github.com/oicr-gsi/bam-qc-metrics.git)
 * [mosdepth 0.2.9](https://github.com/brentp/mosdepth)
 
 
@@ -28,110 +28,51 @@ Parameter|Value|Description
 `inputGroups`|Array[InputGroup]|Array of objects describing sets of bams to merge together and on which to compute QC metrics
 `metadata`|Map[String,String]|JSON file containing metadata
 `mode`|String|running mode for the workflow, only allow value 'lane_level' and 'call_ready'
-`bamQCMetrics.refFasta`|String|Path to human genome FASTA reference
-`bamQCMetrics.refSizesBed`|String|Path to human genome BED reference with chromosome sizes
-`bamQCMetrics.workflowVersion`|String|Workflow version string
+`reference`|String|Reference id, we need it to pick the right reference file
 
 
 #### Optional workflow parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
+`targetBed`|String?|None|Path to optional target bed file
 `outputFileNamePrefix`|String|"bamQC"|Prefix for output files
-`intervalsToParallelizeByString`|String|"chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM"|Comma separated list of intervals to split by (e.g. chr1,chr2,chr3,chr4).
+`runBedtools`|Boolean|false|This is to run bedtools when targetBed is supplied, collect reads on target metric. Default False
+`downsampleToReads`|Int|500000|Downsample to this many reads when running unique read count, duplicate rate calculation and CIGAR analysis
 
 
 #### Optional task parameters:
 Parameter|Value|Default|Description
 ---|---|---|---
-`splitStringToArray.lineSeparator`|String|","|Interval group separator - these are the intervals to split by.
-`splitStringToArray.recordSeparator`|String|"+"|Record separator - a delimiter for joining records
-`splitStringToArray.jobMemory`|Int|1|Memory allocated to job (in GB).
-`splitStringToArray.cores`|Int|1|The number of cores to allocate to the job.
-`splitStringToArray.timeout`|Int|1|Maximum amount of time (in hours) the task can run for.
-`splitStringToArray.modules`|String|""|Environment module name and version to load (space separated) before command execution.
-`getChrCoefficient.memory`|Int|2|Memory allocated for this job
-`getChrCoefficient.timeout`|Int|1|Hours before task timeout
-`getChrCoefficient.modules`|String|"samtools/1.14"|Names and versions of modules to load
-`preFilter.filterFlags`|Int|260|Samtools filter flags to apply.
-`preFilter.minMapQuality`|Int?|None|Minimum alignment quality to pass filter
-`preFilter.filterAdditionalParams`|String?|None|Additional parameters to pass to samtools.
-`preFilter.modules`|String|"samtools/1.14"|required environment modules
-`preFilter.jobMemory`|Int|6|Memory allocated for this job
-`preFilter.minMemory`|Int|2|Minimum amount of RAM allocated to the task
-`preFilter.threads`|Int|4|Requested CPU threads
-`preFilter.timeout`|Int|4|hours before task timeout
-`mergeSplitByIntervalFiles.suffix`|String|".merge"|suffix to use for merged bam
-`mergeSplitByIntervalFiles.jobMemory`|Int|24|Memory allocated to job (in GB).
-`mergeSplitByIntervalFiles.overhead`|Int|6|Java overhead memory (in GB). jobMemory - overhead == java Xmx/heap memory.
-`mergeSplitByIntervalFiles.cores`|Int|1|The number of cores to allocate to the job.
-`mergeSplitByIntervalFiles.timeout`|Int|24|Maximum amount of time (in hours) the task can run for.
-`mergeSplitByIntervalFiles.modules`|String|"gatk/4.1.6.0"|Environment module name and version to load (space separated) before command execution.
-`mergeFiles.suffix`|String|".merge"|suffix to use for merged bam
-`mergeFiles.jobMemory`|Int|24|Memory allocated to job (in GB).
-`mergeFiles.overhead`|Int|6|Java overhead memory (in GB). jobMemory - overhead == java Xmx/heap memory.
-`mergeFiles.cores`|Int|1|The number of cores to allocate to the job.
-`mergeFiles.timeout`|Int|24|Maximum amount of time (in hours) the task can run for.
-`mergeFiles.modules`|String|"gatk/4.1.6.0"|Environment module name and version to load (space separated) before command execution.
-`filter.minQuality`|Int|30|Minimum alignment quality to pass filter
-`filter.modules`|String|"samtools/1.14"|required environment modules
-`filter.jobMemory`|Int|16|Memory allocated for this job
-`filter.threads`|Int|4|Requested CPU threads
-`filter.timeout`|Int|4|hours before task timeout
-`updateMetadata.modules`|String|"python/3.6"|required environment modules
-`updateMetadata.jobMemory`|Int|16|Memory allocated for this job
-`updateMetadata.threads`|Int|4|Requested CPU threads
-`updateMetadata.timeout`|Int|4|hours before task timeout
-`findDownsampleParams.targetReads`|Int|100000|Desired number of reads in downsampled output
-`findDownsampleParams.minReadsAbsolute`|Int|10000|Minimum value of targetReads to allow pre-downsampling
-`findDownsampleParams.minReadsRelative`|Int|2|Minimum value of (inputReads)/(targetReads) to allow pre-downsampling
-`findDownsampleParams.precision`|Int|8|Number of decimal places in fraction for pre-downsampling
-`findDownsampleParams.preDSMultiplier`|Float|1.5|Determines target size for pre-downsampled set (if any). Must have (preDSMultiplier) < (minReadsRelative).
-`findDownsampleParams.modules`|String|"python/3.6"|required environment modules
-`findDownsampleParams.jobMemory`|Int|16|Memory allocated for this job
-`findDownsampleParams.threads`|Int|4|Requested CPU threads
-`findDownsampleParams.timeout`|Int|4|hours before task timeout
-`findDownsampleParamsMarkDup.threshold`|Int|10000000|Minimum number of reads to conduct downsampling
-`findDownsampleParamsMarkDup.chromosomes`|Array[String]|["chr12", "chr13", "chrXII", "chrXIII"]|Array of chromosome identifiers for downsampled subset
-`findDownsampleParamsMarkDup.baseInterval`|Int|15000|Base width of interval in each chromosome, for very large BAMs
-`findDownsampleParamsMarkDup.intervalStart`|Int|100000|Start of interval in each chromosome, for very large BAMs
-`findDownsampleParamsMarkDup.customRegions`|String|""|Custom downsample regions; overrides chromosome and interval parameters
-`findDownsampleParamsMarkDup.modules`|String|"python/3.6"|required environment modules
-`findDownsampleParamsMarkDup.jobMemory`|Int|16|Memory allocated for this job
-`findDownsampleParamsMarkDup.threads`|Int|4|Requested CPU threads
-`findDownsampleParamsMarkDup.timeout`|Int|4|hours before task timeout
-`downsample.downsampleSuffix`|String|"downsampled.bam"|Suffix for output file
-`downsample.randomSeed`|Int|42|Random seed for pre-downsampling (if any)
-`downsample.modules`|String|"samtools/1.14"|required environment modules
-`downsample.jobMemory`|Int|16|Memory allocated for this job
-`downsample.threads`|Int|4|Requested CPU threads
-`downsample.timeout`|Int|4|hours before task timeout
-`downsampleRegion.modules`|String|"samtools/1.14"|required environment modules
-`downsampleRegion.jobMemory`|Int|16|Memory allocated for this job
-`downsampleRegion.threads`|Int|4|Requested CPU threads
-`downsampleRegion.timeout`|Int|4|hours before task timeout
-`markDuplicates.opticalDuplicatePixelDistance`|Int|100|Maximum offset between optical duplicate clusters
-`markDuplicates.picardMaxMemMb`|Int|6000|Memory requirement in MB for running Picard JAR
-`markDuplicates.modules`|String|"picard/2.21.2"|required environment modules
-`markDuplicates.jobMemory`|Int|16|Memory allocated for this job
-`markDuplicates.threads`|Int|4|Requested CPU threads
-`markDuplicates.timeout`|Int|4|hours before task timeout
-`bamQCMetrics.normalInsertMax`|Int|1500|Maximum of expected insert size range
-`bamQCMetrics.modules`|String|"bam-qc-metrics/0.2.5"|required environment modules
-`bamQCMetrics.jobMemory`|Int|16|Memory allocated for this job
-`bamQCMetrics.threads`|Int|4|Requested CPU threads
-`bamQCMetrics.timeout`|Int|4|hours before task timeout
+`samstats.jobMemory`|Int|16|Memory allocated for this job
+`samstats.timeout`|Int|24|hours before task timeout
 `runMosdepth.modules`|String|"mosdepth/0.2.9"|required environment modules
 `runMosdepth.jobMemory`|Int|16|Memory allocated for this job
-`runMosdepth.threads`|Int|4|Requested CPU threads
 `runMosdepth.timeout`|Int|4|hours before task timeout
+`runBedtoolsIntersect.modules`|String|"samtools/1.16.1 bedtools/2.27"|required environment modules
+`runBedtoolsIntersect.jobMemory`|Int|16|Memory allocated for this job
+`runBedtoolsIntersect.timeout`|Int|12|hours before task timeout
 `cumulativeDistToHistogram.modules`|String|"python/3.6"|required environment modules
 `cumulativeDistToHistogram.jobMemory`|Int|8|Memory allocated for this job
 `cumulativeDistToHistogram.threads`|Int|4|Requested CPU threads
 `cumulativeDistToHistogram.timeout`|Int|1|hours before task timeout
-`collateResults.modules`|String|"python/3.6"|required environment modules
-`collateResults.jobMemory`|Int|8|Memory allocated for this job
-`collateResults.threads`|Int|4|Requested CPU threads
-`collateResults.timeout`|Int|1|hours before task timeout
+`markDuplicates.additionalParam`|String?|None|Any additional parameters for samblaster
+`markDuplicates.modules`|String|"samtools/1.16.1"|required environment modules
+`markDuplicates.jobMemory`|Int|16|Memory allocated for this job
+`markDuplicates.threads`|Int|4|Requested CPU threads
+`markDuplicates.timeout`|Int|4|hours before task timeout
+`getUniqueReadsCount.modules`|String|"samtools/1.16.1"|required environment modules
+`getUniqueReadsCount.jobMemory`|Int|16|Memory allocated for this job
+`getUniqueReadsCount.timeout`|Int|18|hours before task timeout
+`bamQCMetrics.targetBed`|File?|None|Optional target bed
+`bamQCMetrics.workflowVersion`|String|"5.3.0"|Workflow version to put into report
+`bamQCMetrics.modules`|String|"bam-qc-metrics/0.2.6"|required environment modules
+`bamQCMetrics.bamQClite`|String|"$BAM_QC_METRICS_ROOT/bin/run_bam_qc_lite.py"|Path to bamQC lite script
+`bamQCMetrics.jobMemory`|Int|8|Memory allocated for this job
+`bamQCMetrics.timeout`|Int|12|hours before task timeout
+`mergeReports.modules`|String|"bam-qc-metrics/0.2.6"|Runtime modules
+`mergeReports.bamQCmerger`|String|"$BAM_QC_METRICS_ROOT/bin/bam_qc_merger.py"|Path to the merger script
+`mergeReports.jobMemory`|Int|4|RAM allocated to run the merging task
+`mergeReports.timeout`|Int|2|Timeout in hours for the merging task
 
 
 ### Outputs
@@ -141,308 +82,134 @@ Output | Type | Description | Labels
 `result`|File|json file that contains metrics and meta data described in https://github.com/oicr-gsi/bam-qc-metrics/blob/master/metrics.md|vidarr_label: result
 
 
-This section lists command(s) run by WORKFLOW workflow
-  
-### Run getChrCoefficient
+## Commands
+This section lists command(s) run by bamQC lite workflow
+ 
+* Running bamQC lite
+ 
+bamQC lite gets most of it's metrics from external tools (except the ones it generates by running CIGAR analysis on downsampled data). 
+It has fewer steps then the original bamQC but produces almost exact results.
+ 
+### Run samstats on unaltered inputs
  
 ```
- 
-  CHROM_LEN=$(samtools view -H ~{bamFile} | grep ^@SQ | grep -v _ | grep -w ~{chromosome} | cut -f 3 | sed 's/LN://')
-  LARGEST=$(samtools view -H ~{bamFile} | grep ^@SQ | grep -v _ | cut -f 3 | sed 's/LN://' | sort -n | tail -n 1)
-  echo | awk -v chrom_len=$CHROM_LEN -v largest=$LARGEST '{print int((chrom_len/largest + 0.1) * 10)/10}'
- 
+     samtools stats ~{bamFile} -r  ~{referenceFile} > ~{filePrefix}.stats
 ```
  
-### Run bamQCMetrics
-   
-```
-  run_bam_qc.py \
-   -b ~{bamFile} \
-   -d ~{markDuplicates} \
-   --debug \
-   -i ~{normalInsertMax} \
-   -o ~{resultName} \
-   -r ~{refFasta} \
-   -t ~{refSizesBed} \
-   -T . \
-   -w ~{workflowVersion} \
-   ~{dsInput}
-```
- 
-### Run collateResults
+### Run mosdepth to get coverage metrics
  
 ```
-   python3 <<CODE
-   import json
-   data = json.loads(open("~{bamQCMetricsResult}").read())
-   histogram = json.loads(open("~{histogram}").read())
-   data["coverage histogram"] = histogram
-   metadata = json.loads(open("~{metadata}").read())
-   for key in metadata.keys():
-       data[key] = metadata[key]
-   out = open("~{outputFileName}", "w")
-   json.dump(data, out, sort_keys=True)
-   out.close()
-   CODE
-```
- 
-### Run cumulativeDistToHistogram
- 
-```
-   python3 <<CODE
-   import csv, json
-   summary = open("~{summary}").readlines()
-   globalDist = open("~{globalDist}").readlines()
-   # read chromosome lengths from the summary
-   summaryReader = csv.reader(summary, delimiter="\t")
-   lengthByChr = {}
-   for row in summaryReader:
-       if row[0] == 'chrom' or row[0] == 'total':
- 	  continue # skip initial header row, and final total row
-       lengthByChr[row[0]] = int(row[1])
-   chromosomes = sorted(lengthByChr.keys())
-   # read the cumulative distribution for each chromosome
-   globalReader = csv.reader(globalDist, delimiter="\t")
-   cumDist = {}
-   for k in chromosomes:
-       cumDist[k] = {}
-   for row in globalReader:
-       if row[0]=="total":
- 	  continue
-       cumDist[row[0]][int(row[1])] = float(row[2])
-   # convert the cumulative distributions to non-cumulative and populate histogram
-   # if the input BAM is empty, chromosomes and histogram will also be empty
-   histogram = {}
-   for k in chromosomes:
-       depths = sorted(cumDist[k].keys())
-       dist = {}
-       for i in range(len(depths)-1):
- 	  depth = depths[i]
- 	  nextDepth = depths[i+1]
- 	  dist[depth] = cumDist[k][depth] - cumDist[k][nextDepth]
-       maxDepth = max(depths)
-       dist[maxDepth] = cumDist[k][maxDepth]
-       # now find the number of loci at each depth of coverage to construct the histogram
-       for depth in depths:
- 	  loci = int(round(dist[depth]*lengthByChr[k], 0))
- 	  histogram[depth] = histogram.get(depth, 0) + loci
-   # if histogram is non-empty, fill in zero values for missing depths
-   for i in range(max(histogram.keys(), default=0)):
-       if i not in histogram:
- 	  histogram[i] = 0
-   out = open("~{outFileName}", "w")
-   json.dump(histogram, out, sort_keys=True)
-   out.close()
-   CODE
-```
- 
-### Run downsample 
- 
-```
-     set -e
-     set -o pipefail
-     samtools view -b -h ~{bamFile} | \
-     ~{preDownsampleCommand} ~{downsampleCommand} \
-     samtools view -b > ~{resultName}
-```
- 
-### downsampleRegion
- 
-```
-     set -e
+     set -eo pipefail
      # ensure BAM file and index are symlinked to working directory
      ln -s ~{bamFile}
      ln -s ~{bamIndex}
-     samtools view -b -h ~{bamFileName} ~{region} > ~{resultName}
+     # run mosdepth
+     MOSDEPTH_PRECISION=8 mosdepth -x -n -t 3 bamqc ~{bamFileName} ~{"--by " + targetBed}
 ```
  
-### Run filter
+### Extract coverage histogram
  
 ```
-     set -e
-     set -o pipefail
-     samtools view -h -b -F 2304 -U ~{nonPrimaryReadsFile} ~{bamFile} | \
-     samtools view -h -b -F 4 -U ~{unmappedReadsFile} | \
-     samtools view -h -b -q ~{minQuality} -U ~{lowQualityReadsFile} \
-     > ~{resultName}
-     samtools view -c ~{bamFile} > ~{totalInputReadsFile}
-     samtools view -c ~{nonPrimaryReadsFile} > ~{totalNonPrimaryReadsFile}
-     samtools view -c ~{unmappedReadsFile} > ~{totalUnmappedReadsFile}
-     samtools view -c ~{lowQualityReadsFile} > ~{totalLowQualityReadsFile}
-     samtools index ~{bamFile} > ~{resultIndexName}
+         python3 <<CODE
+         import csv, json
+         summary = open("~{summary}").readlines()
+         globalDist = open("~{globalDist}").readlines()
+         # read chromosome lengths from the summary
+         summaryReader = csv.reader(summary, delimiter="\t")
+         lengthByChr = {}
+         for row in summaryReader:
+           if row[0] == 'chrom' or row[0] == 'total':
+             continue # skip initial header row, and final total row
+           if row[0].endswith('_region'):
+             continue # skip contigs from target file, if passed
+           lengthByChr[row[0]] = int(row[1])
+         chromosomes = sorted(lengthByChr.keys())
+         # read the cumulative distribution for each chromosome
+         globalReader = csv.reader(globalDist, delimiter="\t")
+         cumDist = {}
+         for k in chromosomes:
+           cumDist[k] = {}
+         for row in globalReader:
+           if row[0]=="total":
+             continue
+           cumDist[row[0]][int(row[1])] = float(row[2])
+         # convert the cumulative distributions to non-cumulative and populate histogram
+         # if the input BAM is empty, chromosomes and histogram will also be empty
+         histogram = {}
+         for k in chromosomes:
+           depths = sorted(cumDist[k].keys())
+           dist = {}
+           for i in range(len(depths)-1):
+             depth = depths[i]
+             nextDepth = depths[i+1]
+             dist[depth] = cumDist[k][depth] - cumDist[k][nextDepth]
+           maxDepth = max(depths)
+           dist[maxDepth] = cumDist[k][maxDepth]
+           # now find the number of loci at each depth of coverage to construct the histogram
+           for depth in depths:
+             loci = int(round(dist[depth]*lengthByChr[k], 0))
+             histogram[depth] = histogram.get(depth, 0) + loci
+         # if histogram is non-empty, fill in zero values for missing depths
+         for i in range(max(histogram.keys(), default=0)):
+           if i not in histogram:
+             histogram[i] = 0
+         out = open("~{outFileName}", "w")
+         json.dump(histogram, out, sort_keys=True)
+         out.close()
+         CODE
 ```
  
-### Run findDownsampleParams
+### Extract duplicate reads metrics with samblaster
+ 
+samblaster uses downsampled data piped into the tool. This allows having a much reduced filesystem footprint
+as there are no intermediate files generated in the process
  
 ```
-     python3 <<CODE
-     import json, math, sys
-     readsIn = ~{inputReads}
-     readsTarget = ~{targetReads}
-     precision = ~{precision}
-     print("Input reads param =", readsIn, file=sys.stderr)
-     print("Target reads param =", readsTarget, file=sys.stderr)
-     minReadsAbsolute = ~{minReadsAbsolute}
-     minReadsRelative = ~{minReadsRelative}
-     preDownsampleMultiplier = ~{preDSMultiplier}
-     if readsIn <= readsTarget:
-       # absolutely no downsampling
-       applyPreDownsample = False
-       applyDownsample = False
-       preDownsampleTarget = "no_pre_downsample"
-       downSampleTarget = "no_downsample"
-     elif readsIn < readsTarget * minReadsRelative or readsTarget < minReadsAbsolute:
-       # no predownsampling
-       applyPreDownsample = False
-       applyDownsample = True
-       preDownsampleTarget = "no_pre_downsample"
-       downSampleTarget = str(readsTarget)
-     else:
-       # predownsampling and downsampling
-       applyPreDownsample = True
-       applyDownsample = True
-       probability = (readsTarget * preDownsampleMultiplier)/readsIn
-       formatString = "{:0"+str(precision)+"d}"
-       preDownsampleTarget = formatString.format(int(math.floor(probability * 10**precision)))
-       downSampleTarget = str(readsTarget)
-     status = {
-       "pre_ds": applyPreDownsample,
-       "ds": applyDownsample
-     }
-     targets = {
-       "pre_ds": preDownsampleTarget,
-       "ds": downSampleTarget
-     }
-     statusFile = open("~{statusFile}", "w")
-     json.dump(status, statusFile)
-     statusFile.close()
-     targetFile = open("~{targetsFile}", "w")
-     json.dump(targets, targetFile)
-     targetFile.close()
-     CODE
+     set -euxo pipefail
+     samtools head -n ~{downsampleToReads} ~{bamFile} | \
+     samtools sort -n - | \
+     samtools fixmate -m -O SAM - - | \
+     samblaster --ignoreUnmated ~{additionalParam} --output /dev/null 2> >(tee "~{filePrefix}.markDuplicates.txt")
 ```
  
-### Run findDownsampleParamsMarkDup
+### For targeted sequencing, count reads on target with bedtools
  
 ```
-     python3 <<CODE
-     readsIn = ~{inputReads}
-     threshold = ~{threshold}
-     interval = ~{baseInterval}
-     start = ~{intervalStart} + 1 # start of sub-chromosome window, if needed; exclude telomeres
-     chromosomes = [line.strip() for line in open("~{chromosomesText}").readlines()]
-     customRegions = "~{customRegions}" # overrides other chromosome/interval parameters
-     ds = True # True if downsampling, false otherwise
-     end = None # end of window, if needed
-     if readsIn <= threshold:
-         ds = False # no downsampling
-     elif readsIn <= threshold*10:
-         pass # default to chr12 & chr13 =~ 8% of genome
-     elif readsIn <= threshold*10**2:
-         end = start + interval*10**3 - 1 # default 2*15 million base window ~ 1% of genome
-     elif readsIn <= threshold*10**3:
-         end = start + interval*10**2 - 1
-     elif readsIn <= threshold*10**4:
-         end = start + interval*10 - 1
-     else:
-         end = start + interval - 1
-     if ds:
-         status = "true"
-         if customRegions != "":
-             region = customRegions
-         elif end == None:
-             region = " ".join(chromosomes)
-         else:
-             regions = ["%s:%i-%i" % (chromosome, start, end) for chromosome in chromosomes ]
-             region = " ".join(regions)
-     else:
-         status = "false"
-         region = ""
-     outStatus = open("~{outputStatus}", "w")
-     print(status, file=outStatus)
-     outStatus.close()
-     outRegion = open("~{outputRegion}", "w")
-     print(region, file=outRegion)
-     outRegion.close()
-     CODE
+     bedtools intersect -a ~{inputBam} -b ~{targetBed} -u | samtools view -c | perl -pe 'chomp'
 ```
  
-### Run markDuplicates 
+### Count unique reads on downsampled data (needed for CIGAR metrics)
+ 
+CIGAR metrics are generated using downsampled bam, this step uses the same rate of downsampling
  
 ```
-     java -Xmx~{picardMaxMemMb}M \
-     -jar ${PICARD_ROOT}/picard.jar \
-     MarkDuplicates \
-     INPUT=~{bamFile} \
-     OUTPUT=~{outFileBam} \
-     VALIDATION_STRINGENCY=SILENT \
-     TMP_DIR=${PWD} \
-     METRICS_FILE=~{outFileText} \
-     OPTICAL_DUPLICATE_PIXEL_DISTANCE=~{opticalDuplicatePixelDistance}
+     samtools head -n ~{downsampleToReads} ~{inputBam} | samtools view -F 256 -q 30 -c | perl -pe 'chomp'
 ```
  
-### Run MergeFiles
-  
-```
-    set -euo pipefail
-  
-    gatk --java-options "-Xmx~{jobMemory - overhead}G" MergeSamFiles \
-    ~{sep=" " prefix("--INPUT=", bams)} \
-    --OUTPUT="~{outputFileName}~{suffix}.bam" \
-    --CREATE_INDEX=true \
-    --SORT_ORDER=coordinate \
-    --ASSUME_SORTED=false \
-    --USE_THREADING=true \
-    --VALIDATION_STRINGENCY=SILENT 
-   
-```
- 
-### Run prefilter
+### Run bamQC lite which aggregates metrics into lane-level json report
  
 ```
-  set -e
-  set -o pipefail
-  samtools view -b \
-       -F ~{filterFlags} \
-       ~{"-q " + minMapQuality} \
-       ~{filterAdditionalParams} \
-       ~{bamFile} \
-       ~{sep=" " intervals} > ~{resultName}
+         set -euxo pipefail
+         python3 ~{bamQClite} ~{"-b " + bamFile} \
+         -s ~{samstatsFile} \
+         -d ~{markDuplicatesStats} \
+         -c ~{histogram} \
+         -m ~{metadataJson} \
+         -w ~{workflowVersion} ~{"-tf " + targetBed} \
+         -r ~{referenceFileName} ~{"-S " + downsampleToReads} \
+         -o ~{outputFileName} \
+         -t ~{mosdepthSummary} ~{"-u " + uniqueReads} ~{"-ot " + readsOnTarget} 
 ```
  
-### Run runMosdepth 
+### Run merger script which will combine reports into call-ready report if there are multiple lanes
+ 
+This step will return lane-level report (exact copy of it's input) if there is one lane, but will
+combine metrics into call-ready report if there are multiple lanes
+ 
  
 ```
-  set -eo pipefail
-  # ensure BAM file and index are symlinked to working directory
-  ln -s ~{bamFile}
-  ln -s ~{bamIndex}
-  # run mosdepth
-  MOSDEPTH_PRECISION=8 mosdepth -x -n -t 3 bamqc ~{bamFileName}
-```
- 
-### splitStringToArray
- 
-```
-   set -euo pipefail
-   
-   echo "~{str}" | tr '~{lineSeparator}' '\n' | tr '~{recordSeparator}' '\t'
-```
- 
-### Run updateMetadata
- 
-```
-   python3 <<CODE
-   import json
-   metadata = json.loads(open("~{metadataJson}").read())
-   metadata["total input reads meta"] = ~{totalInputReads}
-   metadata["non-primary reads meta"] = ~{nonPrimaryReads}
-   metadata["unmapped reads meta"] = ~{unmappedReads}
-   metadata["low-quality reads meta"] = ~{lowQualityReads}
-   outFile = open("~{outFileName}", "w")
-   json.dump(metadata, outFile)
-   outFile.close()
-   CODE
+         set -euxo pipefail
+         python3 ~{bamQCmerger} -l ~{sep="," inputs} -o ~{outputFileName}
 ```
 ## Support
 

--- a/bamQC.wdl
+++ b/bamQC.wdl
@@ -5,190 +5,145 @@ struct InputGroup {
   File bamIndex
 }
 
+struct Resources {
+  String refFasta
+  String modules
+}
+
 workflow bamQC {
 
   input {
     Array[InputGroup] inputGroups
     Map[String, String] metadata
+    String? targetBed
     String mode
+    String reference
     String outputFileNamePrefix = "bamQC"
-    String intervalsToParallelizeByString = "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM"
+    Boolean runBedtools = false
+    Int downsampleToReads = 500000
   }
 
   parameter_meta {
-	inputGroups: "Array of objects describing sets of bams to merge together and on which to compute QC metrics"
-	metadata: "JSON file containing metadata"
+    inputGroups: "Array of objects describing sets of bams to merge together and on which to compute QC metrics"
+    metadata: "JSON file containing metadata"
+    targetBed: "Path to optional target bed file"
+    reference: "Reference id, we need it to pick the right reference file"
     mode: "running mode for the workflow, only allow value 'lane_level' and 'call_ready'"
-	outputFileNamePrefix: "Prefix for output files"
-    intervalsToParallelizeByString: "Comma separated list of intervals to split by (e.g. chr1,chr2,chr3,chr4)."
-    }
-
-  if (( mode == "lane_level") && (length(inputGroups) ==1 )) {
-    File laneLevelBam = inputGroups[0].bam
-    File laneLevelBamIndex = inputGroups[0].bamIndex
+    outputFileNamePrefix: "Prefix for output files"
+    runBedtools: "This is to run bedtools when targetBed is supplied, collect reads on target metric. Default False"
+    downsampleToReads: "Downsample to this many reads when running unique read count, duplicate rate calculation and CIGAR analysis"
   }
 
-  if (mode == "call_ready") {
-    call splitStringToArray {
+  Map[String,Resources] resources = {
+    "hg38": {
+      "refFasta": "$HG38_ROOT/hg38_random.fa",
+      "modules": "samtools/1.16.1 hg38/p12"
+    },
+    "hg19": {
+      "refFasta": "$HG19_ROOT/hg19_random.fa",
+      "modules": "samtools/1.16.1 hg19/p13"
+    }
+  }
+
+  
+  # Record mode in metadata, but process whatevever number of files we have
+  scatter (i in inputGroups) {
+   
+        call samstats {
         input:
-            str = intervalsToParallelizeByString
-        }
-    
-    Array[String] intervalsToParallelizeBy = flatten(splitStringToArray.out)
-    scatter (i in inputGroups) {
-        scatter (interval in intervalsToParallelizeBy) {
-        call getChrCoefficient {
-            input:
-            bamFile = i.bam,
-            chromosome = interval
-        } 
-        call preFilter {
-            input:
-            bamFile = i.bam,
-            bamIndex = i.bamIndex,
-            interval = interval,
-            scaleCoefficient = getChrCoefficient.coeff,
-            outputFileName = outputFileNamePrefix
-        }
+          bamFile = i.bam,
+          modules = resources[reference].modules,
+          referenceFile = resources[reference].refFasta
         }
 
-        Array[File] filteredBams = preFilter.filteredBam
-
-        call mergeFiles as mergeSplitByIntervalFiles {
-            input:
-            bams = filteredBams,
-            outputFileName = outputFileNamePrefix
+        call runMosdepth {
+        input:
+          bamFile = i.bam,
+          bamIndex = i.bamIndex,
+          targetBed = targetBed
         }
-    }
-    Array[File] processedBams = mergeSplitByIntervalFiles.mergedBam
 
-    if (length(processedBams) > 1) {
-        call mergeFiles {
-                input:
-                bams = processedBams,
-                outputFileName = outputFileNamePrefix
-            }
-    } 
-    File mergedBam = select_first([mergeFiles.mergedBam, mergeSplitByIntervalFiles.mergedBam[0]])
-    File mergedBamIndex = select_first([mergeFiles.mergedBamIndex, mergeSplitByIntervalFiles.mergedBamIndex[0]])
-  }	
+        # Derive runs on target if there is a .bed file and metric is requested
+        if (defined(targetBed) && runBedtools) {
+          call runBedtoolsIntersect {
+          input:
+            inputBam = i.bam,
+            targetBed = targetBed
+          }
+        }
 
-  File qcReadyBam = select_first([laneLevelBam, mergedBam])
-  File qcReadyBamIndex = select_first([laneLevelBamIndex, mergedBamIndex])
+        call cumulativeDistToHistogram {
+        input:
+          globalDist = runMosdepth.globalDist,
+          summary = runMosdepth.summary
+        }
 
-  call filter {
-    input:
-    bamFile = qcReadyBam,
-    outputFileNamePrefix = outputFileNamePrefix
+        call markDuplicates {
+        input:
+          bamFile = i.bam,
+          downsampleToReads = downsampleToReads
+        }
+
+        call getUniqueReadsCount {
+         input:
+           inputBam = i.bam,
+           downsampleToReads = downsampleToReads
+        }
+        
+        # This task collates the results from prior steps but also runs CIGAR metrics collection on a downsampled file
+        call bamQCMetrics {
+        input:
+          mode = mode,
+          metadata = metadata,
+          bamFile = i.bam, 
+          downsampleToReads = downsampleToReads,
+          readsOnTarget = runBedtoolsIntersect.readsOnTarget,
+          uniqueReads = getUniqueReadsCount.uniqueReads,
+          outputFileNamePrefix = outputFileNamePrefix,
+          samstatsFile = samstats.statsFile,
+          histogram = cumulativeDistToHistogram.histogram,
+          referenceFileName = basename(resources[reference].refFasta),
+          mosdepthSummary = runMosdepth.summary,
+          targetBed = targetBed,
+          markDuplicatesStats = markDuplicates.result
+        }
+
+  }
+   
+  # json merger will either merge multiple inputs or return single-lane report as the final report
+  call mergeReports {
+  input:
+    inputs = bamQCMetrics.result,
+    prefix = outputFileNamePrefix
   }
 
-  call updateMetadata {
-	input:
-	metadata = metadata,
-	outputFileNamePrefix = outputFileNamePrefix,
-	totalInputReads = filter.totalInputReads,
-	nonPrimaryReads = filter.nonPrimaryReads,
-	unmappedReads = filter.unmappedReads,
-	lowQualityReads = filter.lowQualityReads
-    }
+  
+  output {
+    File result = mergeReports.finalReport
+  }
 
-    call findDownsampleParams {
-	input:
-	outputFileNamePrefix = outputFileNamePrefix,
-	inputReads = filter.totalInputReads
-    }
-
-    call findDownsampleParamsMarkDup {
-	input:
-	outputFileNamePrefix = outputFileNamePrefix,
-	inputReads = filter.totalInputReads
-    }
-
-    Boolean ds = findDownsampleParams.status["ds"]
-    Boolean dsMarkDup = findDownsampleParamsMarkDup.status
-
-    if (ds) {
-	call downsample {
-	    input:
-	    bamFile = filter.filteredBam,
-	    outputFileNamePrefix = outputFileNamePrefix,
-	    downsampleStatus = findDownsampleParams.status,
-	    downsampleTargets = findDownsampleParams.targets,
-	}
-    }
-
-    if (dsMarkDup) {
-	call downsampleRegion {
-	    input:
-	    bamFile = filter.filteredBam,
-        bamIndex = filter.filteredBai,
-	    outputFileNamePrefix = outputFileNamePrefix,
-	    region = findDownsampleParamsMarkDup.region
-	}
-    }
-
-    Array[File?] markDupInputs = [downsampleRegion.result, filter.filteredBam]
-    call markDuplicates {
-	input:
-	bamFile = select_first(markDupInputs),
-	outputFileNamePrefix = outputFileNamePrefix
-    }
-
-    call bamQCMetrics {
-	input:
-	bamFile = filter.filteredBam,
-	outputFileNamePrefix = outputFileNamePrefix,
-	markDuplicates = markDuplicates.result,
-	downsampled = ds,
-	bamFileDownsampled = downsample.result
-    }
-
-    call runMosdepth {
-	input:
-	bamFile = filter.filteredBam,
-	bamIndex = filter.filteredBai
-    }
-
-    call cumulativeDistToHistogram {
-	input:
-	globalDist = runMosdepth.globalDist,
-	summary = runMosdepth.summary
-    }
-
-    call collateResults {
-	input:
-	bamQCMetricsResult = bamQCMetrics.result,
-	metadata = updateMetadata.result,
-	histogram = cumulativeDistToHistogram.histogram,
-	outputFileNamePrefix = outputFileNamePrefix
-    }
-
-    output {
-	File result = collateResults.result
-    }
-
-    meta {
-        author: "Iain Bancarz"
-        email: "ibancarz@oicr.on.ca"
-        description: "bamQC workflow collects a number of metrics which are computed using several methods (by employing third-party software tools along with some custom code) and outputs the results in JSON format. The output also contains metadata, such as the instrument and lane names. Also, it contains the estimate of ribosomal rRNA contamination and other information. bamQC supports downsampling for faster analysis and splits some tasks by chromosome, which also increases speed."
+  meta {
+        author: "Iain Bancarz, Savo Lazic, Peter Ruzanov"
+        email: "ibancarz@oicr.on.ca, slazic@oicr.on.ca, pruzanov@oicr.on.ca"
+        description: "bamQC workflow collects a number of metrics which are computed using several methods (by employing third-party software tools along with some custom code) and outputs the results in JSON format. The output also contains metadata, such as the instrument and lane names. bamQC supports downsampling for faster analysis."
         dependencies: [
             {
-                name: "samtools/1.14",
+                name: "samtools/1.16.1",
                 url: "https://github.com/samtools/samtools"
             },
             {
-                name: "picard/2.21.2",
-                url: "https://broadinstitute.github.io/picard/command-line-overview.html"
+                name: "samblaster/0.1.26",
+                url: "https://github.com/GregoryFaust/samblaster"
             },
             {
                 name: "python/3.6",
                 url: "https://www.python.org/downloads/"
             },
             {
-                name: "bam-qc-metrics/0.2.5",
+                name: "bam-qc-metrics/0.2.6",
                 url: "https://github.com/oicr-gsi/bam-qc-metrics.git"
-            },
-                {
+            }, 
+            {
                 name: "mosdepth/0.2.9",
                 url: "https://github.com/brentp/mosdepth"
             }
@@ -198,202 +153,140 @@ workflow bamQC {
         description: "json file that contains metrics and meta data described in https://github.com/oicr-gsi/bam-qc-metrics/blob/master/metrics.md",
         vidarr_label: "result"
     }
-}
     }
-
+  }
 }
 
 # ================================================================
-#  Scaling coefficient - use to scale RAM allocation by chromosome
+#  1 of 8 : run samstats, extract selected metrics
 # ================================================================
-task getChrCoefficient {
-  input {
-    Int memory = 2
-    Int timeout = 1
-    String chromosome
-    String modules = "samtools/1.14"
+task samstats {
+
+    # run the stats to get non-primary, unmapped, and low-quality aligned reads
+    # return filtered read counts
+
+   input {
     File bamFile
-  }
+    String referenceFile
+    String modules 
+    Int jobMemory = 16
+    Int timeout = 24
+    }
 
-  parameter_meta {
-    bamFile: ".bam file to process, we just need the header"
-    timeout: "Hours before task timeout"
-    chromosome: "Chromosome to check"
-    memory: "Memory allocated for this job"
-    modules: "Names and versions of modules to load"
-  }
+    parameter_meta {
+    bamFile: "Input BAM file of aligned rnaSeqQC data"
+    referenceFile: "Reference fasta file, needed for MPC stats"
+    modules: "required environment modules"
+    jobMemory: "Memory allocated for this job"
+    timeout: "hours before task timeout"
+    }
 
-  command <<<
-    CHROM_LEN=$(samtools view -H ~{bamFile} | grep ^@SQ | grep -v _ | grep -w ~{chromosome} | cut -f 3 | sed 's/LN://')
-    LARGEST=$(samtools view -H ~{bamFile} | grep ^@SQ | grep -v _ | cut -f 3 | sed 's/LN://' | sort -n | tail -n 1)
-    echo | awk -v chrom_len=$CHROM_LEN -v largest=$LARGEST '{print int((chrom_len/largest + 0.1) * 10)/10}'
-  >>>
+    String filePrefix = basename(bamFile, ".bam")
 
-  runtime {
-    memory:  "~{memory} GB"
+    # -F 2304 excludes secondary and supplementary alignments
+    # -F 4 excludes unmapped reads
+
+    command <<<
+    samtools stats ~{bamFile} -r  ~{referenceFile} > ~{filePrefix}.stats
+    >>>
+
+    runtime {
     modules: "~{modules}"
+    memory:  "~{jobMemory} GB"
     timeout: "~{timeout}"
-  }
+    }
 
-  output {
-    String coeff = read_string(stdout())
-  }
+    # record read totals as String, not Int, to avoid integer overflow error
+    output {
+      File statsFile = "~{filePrefix}.stats"
+    }
 
-  meta {
+    meta {
     output_meta: {
-      coeff: "Length ratio as relative to the largest chromosome."
+      statsFile: "File with bam file stats"
     }
-  }
+    }
+
 }
 
 
-task bamQCMetrics {
+# ================================================================
+#  2 of 8 : run Mosdepth, extract coverage distribution data
+# ================================================================
+task runMosdepth {
 
     input {
-	File bamFile
-	String outputFileNamePrefix
-	File markDuplicates
-	Boolean downsampled
-	File? bamFileDownsampled
-	String refFasta
-	String refSizesBed
-	String workflowVersion
-	Int normalInsertMax = 1500
-	String modules = "bam-qc-metrics/0.2.5"
-	Int jobMemory = 16
-	Int threads = 4
-	Int timeout = 4
+    File bamFile
+    File bamIndex
+    String modules = "mosdepth/0.2.9"
+    String? targetBed
+    Int jobMemory = 16
+    Int timeout = 4
     }
 
     parameter_meta {
-	bamFile: "Input BAM file of aligned rnaSeqQC data. Not downsampled; may be filtered."
-	outputFileNamePrefix: "Prefix for output file"
-	markDuplicates: "Text file output from markDuplicates task"
-	downsampled: "True if downsampling has been applied"
-	bamFileDownsampled: "(Optional) downsampled subset of reads from bamFile."
-	refFasta: "Path to human genome FASTA reference"
-	refSizesBed: "Path to human genome BED reference with chromosome sizes"
-	workflowVersion: "Workflow version string"
-	normalInsertMax: "Maximum of expected insert size range"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
+    bamFile: "Input BAM file of aligned data"
+    bamIndex: "Index file in samtools .bai format"
+    modules: "required environment modules"
+    targetBed: "Optional target bed file"
+    jobMemory: "Memory allocated for this job"
+    timeout: "hours before task timeout"
     }
-
-    String dsInput = if downsampled then "-S ~{bamFileDownsampled}" else ""
-    String resultName = "~{outputFileNamePrefix}.metrics.json"
-
-    command <<<
-	run_bam_qc.py \
-	-b ~{bamFile} \
-	-d ~{markDuplicates} \
-	--debug \
-	-i ~{normalInsertMax} \
-	-o ~{resultName} \
-	-r ~{refFasta} \
-	-t ~{refSizesBed} \
-	-T . \
-	-w ~{workflowVersion} \
-	~{dsInput}
-    >>>
 
     runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
+    modules: "~{modules}"
+    memory:  "~{jobMemory} GB"
+    timeout: "~{timeout}"
     }
 
+    String bamFileName = basename(bamFile)
+
+    command <<<
+    set -eo pipefail
+    # ensure BAM file and index are symlinked to working directory
+    ln -s ~{bamFile}
+    ln -s ~{bamIndex}
+    # run mosdepth
+    MOSDEPTH_PRECISION=8 mosdepth -x -n -t 3 bamqc ~{bamFileName} ~{"--by " + targetBed}
+    >>>
+
     output {
-	File result = "~{resultName}"
+    File globalDist = "bamqc.mosdepth.global.dist.txt"
+    File summary = "bamqc.mosdepth.summary.txt"
+    File? targetCoverage = "bamqc.regions.bed.gz"
     }
 
     meta {
-	output_meta: {
-            output1: "JSON file with bam-qc-metrics output"
-	}
+    output_meta: {
+            globalDist: "Global distribution of coverage",
+        summary: "Total bases in coverage"
+    }
   }
 
 }
 
-task collateResults {
 
-    input {
-	File bamQCMetricsResult
-	File histogram
-	File metadata
-	String outputFileNamePrefix
-	String modules = "python/3.6"
-	Int jobMemory = 8
-	Int threads = 4
-	Int timeout = 1
-    }
-
-    parameter_meta {
-	bamQCMetricsResult: "JSON result file from bamQCMetrics"
-	histogram: "JSON file with coverage histogram"
-	metadata: "JSON file with additional metadata"
-	outputFileNamePrefix: "Prefix for output file"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
-    }
-
-    runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
-    }
-
-    String outputFileName = "~{outputFileNamePrefix}.bamQC_results.json"
-
-    command <<<
-        python3 <<CODE
-        import json
-        data = json.loads(open("~{bamQCMetricsResult}").read())
-        histogram = json.loads(open("~{histogram}").read())
-        data["coverage histogram"] = histogram
-        metadata = json.loads(open("~{metadata}").read())
-        for key in metadata.keys():
-            data[key] = metadata[key]
-        out = open("~{outputFileName}", "w")
-        json.dump(data, out, sort_keys=True)
-        out.close()
-        CODE
-    >>>
-
-    output {
-	File result = "~{outputFileName}"
-    }
-
-    meta {
-	output_meta: {
-            output1: "JSON file of collated results"
-	}
-    }
-}
-
+# ================================================================
+#  3 of 8 : format histogram data using mosDepth output
+# ================================================================
 task cumulativeDistToHistogram {
 
     input {
-	File globalDist
-	File summary
-	String modules = "python/3.6"
-	Int jobMemory = 8
-	Int threads = 4
-	Int timeout = 1
+    File globalDist
+    File summary
+    String modules = "python/3.6"
+    Int jobMemory = 8
+    Int threads = 4
+    Int timeout = 1
     }
 
     parameter_meta {
-	globalDist: "Global coverage distribution output from mosdepth"
-	summary: "Summary output from mosdepth"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
+    globalDist: "Global coverage distribution output from mosdepth"
+    summary: "Summary output from mosdepth"
+    modules: "required environment modules"
+    jobMemory: "Memory allocated for this job"
+    threads: "Requested CPU threads"
+    timeout: "hours before task timeout"
     }
 
     String outFileName = "coverage_histogram.json"
@@ -415,39 +308,41 @@ task cumulativeDistToHistogram {
         summaryReader = csv.reader(summary, delimiter="\t")
         lengthByChr = {}
         for row in summaryReader:
-            if row[0] == 'chrom' or row[0] == 'total':
-                continue # skip initial header row, and final total row
-            lengthByChr[row[0]] = int(row[1])
+          if row[0] == 'chrom' or row[0] == 'total':
+            continue # skip initial header row, and final total row
+          if row[0].endswith('_region'):
+            continue # skip contigs from target file, if passed
+          lengthByChr[row[0]] = int(row[1])
         chromosomes = sorted(lengthByChr.keys())
         # read the cumulative distribution for each chromosome
         globalReader = csv.reader(globalDist, delimiter="\t")
         cumDist = {}
         for k in chromosomes:
-            cumDist[k] = {}
+          cumDist[k] = {}
         for row in globalReader:
-            if row[0]=="total":
-                continue
-            cumDist[row[0]][int(row[1])] = float(row[2])
+          if row[0]=="total":
+            continue
+          cumDist[row[0]][int(row[1])] = float(row[2])
         # convert the cumulative distributions to non-cumulative and populate histogram
         # if the input BAM is empty, chromosomes and histogram will also be empty
         histogram = {}
         for k in chromosomes:
-            depths = sorted(cumDist[k].keys())
-            dist = {}
-            for i in range(len(depths)-1):
-                depth = depths[i]
-                nextDepth = depths[i+1]
-                dist[depth] = cumDist[k][depth] - cumDist[k][nextDepth]
-            maxDepth = max(depths)
-            dist[maxDepth] = cumDist[k][maxDepth]
-            # now find the number of loci at each depth of coverage to construct the histogram
-            for depth in depths:
-                loci = int(round(dist[depth]*lengthByChr[k], 0))
-                histogram[depth] = histogram.get(depth, 0) + loci
+          depths = sorted(cumDist[k].keys())
+          dist = {}
+          for i in range(len(depths)-1):
+            depth = depths[i]
+            nextDepth = depths[i+1]
+            dist[depth] = cumDist[k][depth] - cumDist[k][nextDepth]
+          maxDepth = max(depths)
+          dist[maxDepth] = cumDist[k][maxDepth]
+          # now find the number of loci at each depth of coverage to construct the histogram
+          for depth in depths:
+            loci = int(round(dist[depth]*lengthByChr[k], 0))
+            histogram[depth] = histogram.get(depth, 0) + loci
         # if histogram is non-empty, fill in zero values for missing depths
         for i in range(max(histogram.keys(), default=0)):
-            if i not in histogram:
-                histogram[i] = 0
+          if i not in histogram:
+            histogram[i] = 0
         out = open("~{outFileName}", "w")
         json.dump(histogram, out, sort_keys=True)
         out.close()
@@ -455,775 +350,284 @@ task cumulativeDistToHistogram {
     >>>
 
     runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
+    modules: "~{modules}"
+    memory:  "~{jobMemory} GB"
+    cpu:     "~{threads}"
+    timeout: "~{timeout}"
     }
 
     output {
-	File histogram = "~{outFileName}"
+    File histogram = "~{outFileName}"
     }
 
     meta {
-	output_meta: {
-	    histogram: "Coverage histogram in JSON format"
-	}
+    output_meta: {
+        histogram: "Coverage histogram in JSON format"
+    }
     }
 }
 
-task downsample {
 
-    # random downsampling for QC metrics (excepting MarkDuplicates)
-
-    input {
-	File bamFile
-	String outputFileNamePrefix
-	Map[String, Boolean] downsampleStatus
-	Map[String, String] downsampleTargets
-	String downsampleSuffix = "downsampled.bam"
-	Int randomSeed = 42
-	String modules = "samtools/1.14"
-	Int jobMemory = 16
-	Int threads = 4
-	Int timeout = 4
-    }
-
-    parameter_meta {
-	bamFile: "Input BAM file of aligned rnaSeqQC data"
-	outputFileNamePrefix: "Prefix for output file"
-	downsampleStatus: "Map; whether to apply pre-downsampling and downsampling"
-	downsampleTargets: "Map; target number of reads for pre-downsampling and downsampling"
-	downsampleSuffix: "Suffix for output file"
-	randomSeed: "Random seed for pre-downsampling (if any)"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
-    }
-
-    String resultName = "~{outputFileNamePrefix}.~{downsampleSuffix}"
-
-    # unpack downsample parameters
-    Boolean applyPreDownsample = downsampleStatus["pre_ds"]
-    String preDownsampleTarget = downsampleTargets["pre_ds"]
-    String downsampleTarget = downsampleTargets["ds"]
-
-    # generate downsample commands
-    # preDownsample = fast, random selection of approximate total with samtools view
-    String preDownsample = "samtools view -h -u -s ~{randomSeed}.~{preDownsampleTarget} | "
-    String preDownsampleCommand = if applyPreDownsample then "~{preDownsample}" else ""
-    # downsample = slow, deterministic selection of exact total with samtools collate and sort
-    # see https://github.com/samtools/samtools/issues/931
-    String dsCollate = "samtools collate -O --output-fmt sam - | "
-    String dsAwk = "awk '/^@/ { print; next } count < ~{downsampleTarget} || last == $1 { print; last = $1; count++ }' | "
-    String dsSort = "samtools sort -T downsample_sort - | "
-    String downsampleCommand = "~{dsCollate}~{dsAwk}~{dsSort}"
-    
-    command <<<
-	set -e
-	set -o pipefail
-	samtools view -b -h ~{bamFile} | \
-	~{preDownsampleCommand} ~{downsampleCommand} \
-	samtools view -b > ~{resultName}
-    >>>
-
-    runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
-    }
-
-    output {
-	File result = "~{resultName}"
-    }
-    
-    meta {
-	output_meta: {
-            result: "BAM file downsampled to required number of reads"
-	}
-    }
-
-}
-
-task downsampleRegion {
-
-    # downsample a specific chromosomal region for MarkDuplicates
-    # this keeps a proportionate level of duplicates in the downsampled data
-
-    input {
-	File bamFile
-	File bamIndex
-	String outputFileNamePrefix
-	String region
-	String modules = "samtools/1.14"
-	Int jobMemory = 16
-	Int threads = 4
-	Int timeout = 4
-    }
-
-    parameter_meta {
-	bamFile: "Input BAM file"
-	bamIndex: "BAM index file in BAI format"
-	outputFileNamePrefix: "Prefix for output file"
-	region: "Region argument for samtools"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
-    }
-
-    String bamFileName = basename(bamFile)
-    String resultName = "~{outputFileNamePrefix}.downsampledRegion.bam"
-
-    # need to index the (filtered) BAM file before viewing a specific chromosome
-
-    command <<<
-	set -e
-	# ensure BAM file and index are symlinked to working directory
-	ln -s ~{bamFile}
-	ln -s ~{bamIndex}
-	samtools view -b -h ~{bamFileName} ~{region} > ~{resultName}
-    >>>
-
-    runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
-    }
-
-    output {
-	File result = "~{resultName}"
-    }
-
-    meta {
-	output_meta: {
-            result: "BAM file downsampled to required number of reads"
-	}
-    }
-
-}
-
-task filter {
-
-    # filter out non-primary, unmapped, and low-quality aligned reads
-    # count the number of reads filtered out at each step
-    # return filtered read counts and the filtered BAM file
-
-   input {
-	File bamFile
-	String outputFileNamePrefix
-	Int minQuality = 30
-	String modules = "samtools/1.14"
-	Int jobMemory = 16
-	Int threads = 4
-	Int timeout = 4
-    }
-
-    parameter_meta {
-	bamFile: "Input BAM file of aligned rnaSeqQC data"
-	outputFileNamePrefix: "Prefix for output file"
-	minQuality: "Minimum alignment quality to pass filter"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
-    }
-
-    String resultName = "~{outputFileNamePrefix}.filtered.bam"
-    String resultIndexName = "~{outputFileNamePrefix}.filtered.bam.bai"
-    String totalInputReadsFile = "total_input_reads.txt"
-    String totalNonPrimaryReadsFile = "total_non_primary_reads.txt"
-    String totalUnmappedReadsFile = "total_unmapped_reads.txt"
-    String totalLowQualityReadsFile = "total_low_quality_reads.txt"
-    String nonPrimaryReadsFile = "non_primary_reads.bam"
-    String unmappedReadsFile = "unmapped_reads.bam"
-    String lowQualityReadsFile = "low_quality_reads.bam"
-
-    # -F 2304 excludes secondary and supplementary alignments
-    # -F 4 excludes unmapped reads
-
-    command <<<
-    set -e
-    set -o pipefail
-    samtools view -h -b -F 2304 -U ~{nonPrimaryReadsFile} ~{bamFile} | \
-    samtools view -h -b -F 4 -U ~{unmappedReadsFile} | \
-    samtools view -h -b -q ~{minQuality} -U ~{lowQualityReadsFile} \
-    > ~{resultName}
-    samtools view -c ~{bamFile} > ~{totalInputReadsFile}
-    samtools view -c ~{nonPrimaryReadsFile} > ~{totalNonPrimaryReadsFile}
-    samtools view -c ~{unmappedReadsFile} > ~{totalUnmappedReadsFile}
-    samtools view -c ~{lowQualityReadsFile} > ~{totalLowQualityReadsFile}
-    samtools index ~{resultName} ~{resultIndexName}
-    >>>
-
-    runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
-    }
-
-    # record read totals as String, not Int, to avoid integer overflow error
-    output {
-    String totalInputReads = read_string("~{totalInputReadsFile}")
-    String nonPrimaryReads = read_string("~{totalNonPrimaryReadsFile}")
-    String unmappedReads = read_string("~{totalUnmappedReadsFile}")
-    String lowQualityReads = read_string("~{totalLowQualityReadsFile}")
-    File filteredBam = "~{resultName}"
-    File filteredBai = "~{resultIndexName}"
-    }
-
-    meta {
-	output_meta: {
-    totalInputReads: "Total reads in original input BAM file",
-    nonPrimaryReads: "Total reads excluded as non-primary",
-    unmappedReads: "Total reads excluded as unmapped",
-    lowQualityReads: "Total reads excluded as low alignment quality",
-    filteredBam: "Filtered BAM file",
-    filteredBai: "Filtered bam index"
-	}
-    }
-
-}
-
-task findDownsampleParams {
-
-    input {
-	String outputFileNamePrefix
-	String inputReads
-	Int targetReads = 100000
-	Int minReadsAbsolute = 10000
-	Int minReadsRelative = 2
-	Int precision = 8
-	Float preDSMultiplier = 1.5
-	String modules = "python/3.6"
-	Int jobMemory = 16
-	Int threads = 4
-	Int timeout = 4
-    }
-
-    String statusFile = "status.json"
-    String targetsFile = "targets.json"
-
-    parameter_meta {
-	outputFileNamePrefix: "Prefix for output file"
-	inputReads: "Number of reads in input bamFile (represented as string to avoid integer overflow)"
-	targetReads: "Desired number of reads in downsampled output"
-	minReadsAbsolute: "Minimum value of targetReads to allow pre-downsampling"
-	minReadsRelative: "Minimum value of (inputReads)/(targetReads) to allow pre-downsampling"
-	precision: "Number of decimal places in fraction for pre-downsampling"
-	preDSMultiplier: "Determines target size for pre-downsampled set (if any). Must have (preDSMultiplier) < (minReadsRelative)."
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
-    }
-
-    # see comments in "task downsample" for effect of predownsampling and downsampling
-
-    # target for predownsampling with "samtools view -s" is expressed as a probability
-    # eg. to choose approximately 200 reads out of 10000, target = 0.02
-    # we convert to a fixed-precision target string for easier handling in BASH
-    # eg. 0.02 -> "020000"
-    # subsequently, we concatenate in the form {$RANDOM_SEED}.${TARGET}, eg. "42.020000"
-    # for consistency, express downsampling target (integer number of reads) as a string also
-    
-    command <<<
-        python3 <<CODE
-        import json, math, sys
-        readsIn = ~{inputReads}
-        readsTarget = ~{targetReads}
-        precision = ~{precision}
-        print("Input reads param =", readsIn, file=sys.stderr)
-        print("Target reads param =", readsTarget, file=sys.stderr)
-        minReadsAbsolute = ~{minReadsAbsolute}
-        minReadsRelative = ~{minReadsRelative}
-        preDownsampleMultiplier = ~{preDSMultiplier}
-        if readsIn <= readsTarget:
-          # absolutely no downsampling
-          applyPreDownsample = False
-          applyDownsample = False
-          preDownsampleTarget = "no_pre_downsample"
-          downSampleTarget = "no_downsample"
-        elif readsIn < readsTarget * minReadsRelative or readsTarget < minReadsAbsolute:
-          # no predownsampling
-          applyPreDownsample = False
-          applyDownsample = True
-          preDownsampleTarget = "no_pre_downsample"
-          downSampleTarget = str(readsTarget)
-        else:
-          # predownsampling and downsampling
-          applyPreDownsample = True
-          applyDownsample = True
-          probability = (readsTarget * preDownsampleMultiplier)/readsIn
-          formatString = "{:0"+str(precision)+"d}"
-          preDownsampleTarget = formatString.format(int(math.floor(probability * 10**precision)))
-          downSampleTarget = str(readsTarget)
-        status = {
-          "pre_ds": applyPreDownsample,
-          "ds": applyDownsample
-        }
-        targets = {
-          "pre_ds": preDownsampleTarget,
-          "ds": downSampleTarget
-        }
-        statusFile = open("~{statusFile}", "w")
-        json.dump(status, statusFile)
-        statusFile.close()
-        targetFile = open("~{targetsFile}", "w")
-        json.dump(targets, targetFile)
-        targetFile.close()
-        CODE
-    >>>
-
-    runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
-    }
-
-    output {
-	Map[String, Boolean] status = read_json("~{statusFile}")
-	Map[String, String] targets = read_json("~{targetsFile}")
-    }
-
-    meta {
-	output_meta: {
-            status: "Boolean flags indicating whether to apply (pre)downsampling.",
-            output2: "Strings representing target number of reads for (pre)downsampling."
-	}
-    }
-}
-
-task findDownsampleParamsMarkDup {
-
-    # downsampling parameters for MarkDuplicates; see filter_downsample.md for details
-    # choose a region of the genome instead of using random selection
-
-    # a BAM file is *very* approximately 10M reads per GB
-    # Current merged BAM files are unlikely to exceed 10**9 reads; but we scale up higher just in case
-
-    input {
-	String outputFileNamePrefix
-	String inputReads
-	Int threshold = 10000000
-	Array[String] chromosomes = ["chr12", "chr13", "chrXII", "chrXIII"]
-	Int baseInterval = 15000
-	Int intervalStart = 100000
-	String customRegions = ""
-	String modules = "python/3.6"
-	Int jobMemory = 16
-	Int threads = 4
-	Int timeout = 4
-    }
-
-    parameter_meta {
-	outputFileNamePrefix: "Prefix for output file"
-	inputReads: "Number of reads in input bamFile"
-	threshold: "Minimum number of reads to conduct downsampling"
-	chromosomes: "Array of chromosome identifiers for downsampled subset"
-	baseInterval: "Base width of interval in each chromosome, for very large BAMs"
-	intervalStart: "Start of interval in each chromosome, for very large BAMs"
-	customRegions: "Custom downsample regions; overrides chromosome and interval parameters"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
-    }
-
-    String outputStatus = "~{outputFileNamePrefix}_status.txt"
-    String outputRegion = "~{outputFileNamePrefix}_region.txt"
-    File chromosomesText = write_lines(chromosomes)
-
-    command <<<
-        python3 <<CODE
-        readsIn = ~{inputReads}
-        threshold = ~{threshold}
-        interval = ~{baseInterval}
-        start = ~{intervalStart} + 1 # start of sub-chromosome window, if needed; exclude telomeres
-        chromosomes = [line.strip() for line in open("~{chromosomesText}").readlines()]
-        customRegions = "~{customRegions}" # overrides other chromosome/interval parameters
-        ds = True # True if downsampling, false otherwise
-        end = None # end of window, if needed
-        if readsIn <= threshold:
-            ds = False # no downsampling
-        elif readsIn <= threshold*10:
-            pass # default to chr12 & chr13 =~ 8% of genome
-        elif readsIn <= threshold*10**2:
-            end = start + interval*10**3 - 1 # default 2*15 million base window ~ 1% of genome
-        elif readsIn <= threshold*10**3:
-            end = start + interval*10**2 - 1
-        elif readsIn <= threshold*10**4:
-            end = start + interval*10 - 1
-        else:
-            end = start + interval - 1
-        if ds:
-            status = "true"
-            if customRegions != "":
-                region = customRegions
-            elif end == None:
-                region = " ".join(chromosomes)
-            else:
-                regions = ["%s:%i-%i" % (chromosome, start, end) for chromosome in chromosomes ]
-                region = " ".join(regions)
-        else:
-            status = "false"
-            region = ""
-        outStatus = open("~{outputStatus}", "w")
-        print(status, file=outStatus)
-        outStatus.close()
-        outRegion = open("~{outputRegion}", "w")
-        print(region, file=outRegion)
-        outRegion.close()
-        CODE
-    >>>
-
-    output {
-	Boolean status = read_boolean("~{outputStatus}")
-	String region = read_string("~{outputRegion}")
-    }
-
-    meta {
-	output_meta: {
-	    status: "Boolean flag, indicates whether downsampling is required",
-	    region: "String to specify downsampled region for samtools"
-	}
-    }
-}
-
+# ================================================================
+#  4 of 8 : run samblaster to collect read duplicates stats
+# ================================================================
 task markDuplicates {
 
     input {
-	File bamFile
-	String outputFileNamePrefix
-	Int opticalDuplicatePixelDistance=100
-	Int picardMaxMemMb=6000
-	String modules = "picard/2.21.2"
-	Int jobMemory = 16
-	Int threads = 4
-	Int timeout = 4
-    }
-
-    # See GR-899 for opticalDuplicatePixelDistance
-
-    parameter_meta {
-	bamFile: "Input BAM file, after filtering and downsampling (if any)"
-	outputFileNamePrefix: "Prefix for output file"
-	opticalDuplicatePixelDistance: "Maximum offset between optical duplicate clusters"
-	picardMaxMemMb: "Memory requirement in MB for running Picard JAR"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
-    }
-
-    String outFileBam = "~{outputFileNamePrefix}.markDuplicates.bam"
-    String outFileText = "~{outputFileNamePrefix}.markDuplicates.txt"
-
-    command <<<
-	java -Xmx~{picardMaxMemMb}M \
-	-jar ${PICARD_ROOT}/picard.jar \
-	MarkDuplicates \
-	INPUT=~{bamFile} \
-	OUTPUT=~{outFileBam} \
-	VALIDATION_STRINGENCY=SILENT \
-	TMP_DIR=${PWD} \
-	METRICS_FILE=~{outFileText} \
-	OPTICAL_DUPLICATE_PIXEL_DISTANCE=~{opticalDuplicatePixelDistance}
-    >>>
-
-    runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
-    }
-
-    output {
-	File result = "~{outFileText}"
-    }
-
-    meta {
-	output_meta: {
-            result: "Text file with Picard markDuplicates metrics"
-	}
-    }
-
-}
-
-task mergeFiles {
-  input {
-    Array[File] bams
-    String outputFileName
-    String suffix = ".merge"
-    Int jobMemory = 24
-    Int overhead = 6
-    Int cores = 1
-    Int timeout = 24
-    String modules = "gatk/4.1.6.0"
-  }
-
-  parameter_meta {
-    bams: "Array of bam files to merge together."
-    outputFileName: "Output files will be prefixed with this."
-    suffix: "suffix to use for merged bam"
-    jobMemory: "Memory allocated to job (in GB)."
-    overhead: "Java overhead memory (in GB). jobMemory - overhead == java Xmx/heap memory."
-    cores: "The number of cores to allocate to the job."
-    timeout: "Maximum amount of time (in hours) the task can run for."
-    modules: "Environment module name and version to load (space separated) before command execution."
-  }
-
-  command <<<
-    set -euo pipefail
-
-    gatk --java-options "-Xmx~{jobMemory - overhead}G" MergeSamFiles \
-    ~{sep=" " prefix("--INPUT=", bams)} \
-    --OUTPUT="~{outputFileName}~{suffix}.bam" \
-    --CREATE_INDEX=true \
-    --SORT_ORDER=coordinate \
-    --ASSUME_SORTED=false \
-    --USE_THREADING=true \
-    --VALIDATION_STRINGENCY=SILENT 
-
-  >>>
-
-  output {
-    File mergedBam = "~{outputFileName}~{suffix}.bam"
-    File mergedBamIndex = "~{outputFileName}~{suffix}.bai"
-  }
-
-  runtime {
-    memory: "~{jobMemory} GB"
-    cpu: "~{cores}"
-    timeout: "~{timeout}"
-    modules: "~{modules}"
-  }
-
-}
-
-task preFilter {
-    input {
     File bamFile
-    File bamIndex
-    String interval
-    String outputFileName
-    Int filterFlags = 260
-    Int? minMapQuality
-    Float scaleCoefficient = 1.0
-    String? filterAdditionalParams
-    String modules = "samtools/1.14"
-    Int jobMemory = 6
-    Int minMemory = 2
+    String? additionalParam
+    Int downsampleToReads
+    String modules = "samblaster/0.1.26 samtools/1.16.1"
+    Int jobMemory = 16
     Int threads = 4
     Int timeout = 4
     }
-    parameter_meta {
-	bamFile: "Input BAM file of aligned rnaSeqQC data"
-	outputFileName: "Prefix for output file"
-	minMapQuality: "Minimum alignment quality to pass filter"
-        filterFlags: "Samtools filter flags to apply."
-        filterAdditionalParams: "Additional parameters to pass to samtools."
-        interval: "Usually, a chromosome id as it would appear in input .bam header"
-	modules: "required environment modules"
-        scaleCoefficient: "Chromosome-dependent RAM scaling coefficient"
-	jobMemory: "Memory allocated for this job"
-        minMemory: "Minimum amount of RAM allocated to the task"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
-    }
-
-   String resultName = "~{outputFileName}.filtered.bam"
-   Int allocatedMemory = if minMemory > round(jobMemory * scaleCoefficient) then minMemory else round(jobMemory * scaleCoefficient)
-
-   command <<<
-   set -e
-   set -o pipefail
-   samtools view -b \
-        -F ~{filterFlags} \
-        ~{"-q " + minMapQuality} \
-        ~{filterAdditionalParams} \
-        ~{bamFile} \
-        ~{interval} > ~{resultName}
-    >>> 
-
-    output {
-    File filteredBam = "~{resultName}"
-    }
-
-    meta {
-	output_meta: {
-        filteredBam: "Filtered BAM file"
-	}
-    }
-
-    runtime {
-	modules: "~{modules}"
-	memory:  "~{allocatedMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
-    }
-
-}
-
-task runMosdepth {
-
-    input {
-	File bamFile
-	File bamIndex
-	String modules = "mosdepth/0.2.9"
-	Int jobMemory = 16
-	Int threads = 4
-	Int timeout = 4
-    }
 
     parameter_meta {
-	bamFile: "Input BAM file of aligned data"
-	bamIndex: "Index file in samtools .bai format"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
+    bamFile: "Input BAM file, after filtering and downsampling (if any)"
+    additionalParam: "Any additional parameters for samblaster"
+    modules: "required environment modules"
+    jobMemory: "Memory allocated for this job"
+    threads: "Requested CPU threads"
+    timeout: "hours before task timeout"
     }
 
-    runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
-    }
-
-    String bamFileName = basename(bamFile)
+    String filePrefix = basename(bamFile, ".bam")
 
     command <<<
-	set -eo pipefail
-	# ensure BAM file and index are symlinked to working directory
-	ln -s ~{bamFile}
-	ln -s ~{bamIndex}
-	# run mosdepth
-	MOSDEPTH_PRECISION=8 mosdepth -x -n -t 3 bamqc ~{bamFileName}
+    set -euxo pipefail
+    samtools head -n ~{downsampleToReads} ~{bamFile} | \
+    samtools sort -n - | \
+    samtools fixmate -m -O SAM - - | \
+    samblaster --ignoreUnmated ~{additionalParam} --output /dev/null 2> >(tee "~{filePrefix}.markDuplicates.txt")
     >>>
 
+    runtime {
+      modules: "~{modules}"
+      memory:  "~{jobMemory} GB"
+      timeout: "~{timeout}"
+    }
+
     output {
-	File globalDist = "bamqc.mosdepth.global.dist.txt"
-	File summary = "bamqc.mosdepth.summary.txt"
+      File result = "~{filePrefix}.markDuplicates.txt"
     }
 
     meta {
-	output_meta: {
-            globalDist: "Global distribution of coverage",
-	    summary: "Total bases in coverage"
-	}
-  }
+    output_meta: {
+      result: "Text file with samblaster markDuplicates metrics"
+    }
+    }
 
 }
 
-task splitStringToArray {
-  input {
-    String str
-    String lineSeparator = ","
-    String recordSeparator = "+"
-    Int jobMemory = 1
-    Int cores = 1
-    Int timeout = 1
-    String modules = ""
-  }
-
-  command <<<
-    set -euo pipefail
-    echo "~{str}" | tr '~{lineSeparator}' '\n' | tr '~{recordSeparator}' '\t'
-  >>>
-
-  output {
-    Array[Array[String]] out = read_tsv(stdout())
-  }
-
-  runtime {
-    memory: "~{jobMemory} GB"
-    cpu: "~{cores}"
-    timeout: "~{timeout}"
-    modules: "~{modules}"
-  }
-
-  parameter_meta {
-    str: "Interval string to split (e.g. chr1,chr2,chr3+chr4)."
-    lineSeparator: "Interval group separator - these are the intervals to split by."
-    recordSeparator: "Record separator - a delimiter for joining records"
-    jobMemory: "Memory allocated to job (in GB)."
-    cores: "The number of cores to allocate to the job."
-    timeout: "Maximum amount of time (in hours) the task can run for."
-    modules: "Environment module name and version to load (space separated) before command execution."
-  }
-}
-
-task updateMetadata {
-
-    # add extra fields to the metadata JSON file
-
+# =============================================================================
+#  5 of 8: Optional bedtools intersect task to derive reads on target metric, if needed
+# =============================================================================
+task runBedtoolsIntersect {
     input {
-	Map[String, String] metadata
-	String outputFileNamePrefix
-	String totalInputReads
-	String nonPrimaryReads
-	String unmappedReads
-	String lowQualityReads
-	String modules = "python/3.6"
-	Int jobMemory = 16
-	Int threads = 4
-	Int timeout = 4
+    File inputBam
+    File? targetBed
+    String modules = "samtools/1.16.1 bedtools/2.27"
+    Int jobMemory = 16
+    Int timeout = 12
     }
 
     parameter_meta {
-	metadata: "Key/value map of input metadata"
-	outputFileNamePrefix: "Prefix for output file"
-	totalInputReads: "Total reads in original input BAM file"
-	nonPrimaryReads: "Total reads excluded as non-primary"
-	unmappedReads: "Total reads excluded as unmapped"
-	lowQualityReads: "Total reads excluded as low alignment quality"
-	modules: "required environment modules"
-	jobMemory: "Memory allocated for this job"
-	threads: "Requested CPU threads"
-	timeout: "hours before task timeout"
+    inputBam: "Input BAM file, after filtering and downsampling (if any)"
+    targetBed: "Target bed file"
+    modules: "required environment modules"
+    jobMemory: "Memory allocated for this job"
+    timeout: "hours before task timeout"
+    }
+
+    command <<<
+    bedtools intersect -a ~{inputBam} -b ~{targetBed} -u | samtools view -c | perl -pe 'chomp'
+    >>>
+
+    runtime {
+      modules: "~{modules}"
+      memory:  "~{jobMemory} GB"
+      timeout: "~{timeout}"
+    }
+    
+    output {
+      Int readsOnTarget = read_int(stdout())
+    }
+
+    meta {
+    output_meta: {
+      readsOnTarget: "Number of reads on target"
+    }
+    }
+
+}
+
+# =============================================================================
+#  6 of 8: Optional samtools countinting task to get unique reads, if needed
+# =============================================================================
+task getUniqueReadsCount {
+    input {
+    File inputBam
+    Int downsampleToReads
+    String modules = "samtools/1.16.1"
+    Int jobMemory = 16
+    Int timeout = 18
+    }
+
+    parameter_meta {
+    inputBam: "Input BAM file, after filtering and downsampling (if any)"
+    downsampleToReads: "Run the count on this many reads only bed file"
+    modules: "required environment modules"
+    jobMemory: "Memory allocated for this job"
+    timeout: "hours before task timeout"
+    }
+
+    command <<<
+    samtools head -n ~{downsampleToReads} ~{inputBam} | samtools view -F 256 -q 30 -c | perl -pe 'chomp'
+    >>>
+
+    runtime {
+      modules: "~{modules}"
+      memory:  "~{jobMemory} GB"
+      timeout: "~{timeout}"
+    }
+
+    output {
+      Int uniqueReads = read_int(stdout())
+    }
+
+    meta {
+    output_meta: {
+      uniqueReads: "Number of unique reads"
+    }
+    }
+
+}
+
+# ============================================================================
+#  7 of 8 : run bamQCMetrics to assemble lane-level metrics into a json file
+# ============================================================================
+task bamQCMetrics {
+
+    input {
+    String mode
+    File? bamFile
+    Map[String, String] metadata
+    String outputFileNamePrefix
+    File samstatsFile
+    File histogram
+    File markDuplicatesStats
+    File mosdepthSummary
+    File? targetBed
+    Int? readsOnTarget
+    Int? downsampleToReads
+    Int? uniqueReads
+    String referenceFileName
+    String workflowVersion = "5.3.0"
+    String modules = "bam-qc-metrics/0.2.6"
+    String bamQClite = "$BAM_QC_METRICS_ROOT/bin/run_bam_qc_lite.py"
+    Int jobMemory = 8
+    Int timeout = 12
+    }
+
+    parameter_meta {
+    mode: "Either lane_level or call_ready"
+    bamFile: "We pass a bam file only if we want to run CIGAR analysis (long)"
+    bamQClite: "Path to bamQC lite script"
+    outputFileNamePrefix: "Prefix for output file"
+    downsampleToReads: "Downsample to this number of reads, default is defined in bam_qc_lite (500K)"
+    histogram: "JSON file(s) with coverage histogram"
+    metadata: "Map object with additional metadata"
+    samstatsFile: "files with metrics collected by samtools stats"
+    markDuplicatesStats: "stats from markDuplicate step"
+    mosdepthSummary: "Summary file from mosdepth task"
+    targetBed: "Optional target bed"
+    readsOnTarget: "Optional reads on target metric"
+    uniqueReads: "Optional unique reads for calculating reads per start point metric"
+    referenceFileName: "basename of the reference file"
+    workflowVersion: "Workflow version to put into report" 
+    modules: "required environment modules"
+    jobMemory: "Memory allocated for this job"
+    timeout: "hours before task timeout"
     }
 
     runtime {
-	modules: "~{modules}"
-	memory:  "~{jobMemory} GB"
-	cpu:     "~{threads}"
-	timeout: "~{timeout}"
+      modules: "~{modules}"
+      memory:  "~{jobMemory} GB"
+      timeout: "~{timeout}"
     }
 
+    String outputFileName = "~{outputFileNamePrefix}.bamQC_results.json"
     File metadataJson = write_json(metadata)
-    String outFileName = "~{outputFileNamePrefix}.updated_metadata.json"
-
-    # Read totals are Strings in WDL to avoid integer overflow in Cromwell
-    # Python3 can handle arbitrarily large integers
-
+    #TODO: need to check that it runs without setting PYTHONPATH
     command <<<
-        python3 <<CODE
-        import json
-        metadata = json.loads(open("~{metadataJson}").read())
-        metadata["total input reads meta"] = ~{totalInputReads}
-        metadata["non-primary reads meta"] = ~{nonPrimaryReads}
-        metadata["unmapped reads meta"] = ~{unmappedReads}
-        metadata["low-quality reads meta"] = ~{lowQualityReads}
-        outFile = open("~{outFileName}", "w")
-        json.dump(metadata, outFile)
-        outFile.close()
-        CODE
+        set -euxo pipefail
+        # export PYTHONPATH=$PYTHONPATH:/.mounts/labs/gsi/testdata/bamqc/scripts/
+        python3 ~{bamQClite} ~{"-b " + bamFile} \
+        -s ~{samstatsFile} \
+        -d ~{markDuplicatesStats} \
+        -c ~{histogram} \
+        -m ~{metadataJson} \
+        -w ~{workflowVersion} ~{"-tf " + targetBed} \
+        -r ~{referenceFileName} ~{"-S " + downsampleToReads} \
+        -o ~{outputFileName} \
+        -t ~{mosdepthSummary} ~{"-u " + uniqueReads} ~{"-ot " + readsOnTarget} 
     >>>
 
     output {
-	File result = "~{outFileName}"
+      File result = "~{outputFileName}"
     }
 
     meta {
-	output_meta: {
-            result: "JSON file with updated metadata"
-	}
+    output_meta: {
+      output1: "JSON file of collated results"
+    }
+    }
+}
+
+# ==========================================================================================
+# 8 of 8: merge reports from multiple lanes or pass a single-lane report as the final report
+# ==========================================================================================
+task mergeReports {
+    input {
+    Array[File] inputs
+    String prefix
+    String modules = "bam-qc-metrics/0.2.6"
+    String bamQCmerger = "$BAM_QC_METRICS_ROOT/bin/bam_qc_merger.py"
+    Int jobMemory = 4
+    Int timeout = 2
+    }
+
+    parameter_meta {
+      inputs: "Array of .json report files"
+      prefix: "Prefix for output file"
+      modules: "Runtime modules"
+      bamQCmerger: "Path to the merger script"
+      jobMemory: "RAM allocated to run the merging task"
+      timeout: "Timeout in hours for the merging task"
+    }
+
+    runtime {
+      modules: "~{modules}"
+      memory:  "~{jobMemory} GB"
+      timeout: "~{timeout}"
+    }
+
+    String outputFileName = "~{prefix}.bamQC_results.json"
+    #TODO: need to check that it runs without setting PYTHONPATH
+    command <<<
+        set -euxo pipefail
+        # export PYTHONPATH=$PYTHONPATH:/.mounts/labs/gsi/testdata/bamqc/scripts/ 
+        python3 ~{bamQCmerger} -l ~{sep="," inputs} -o ~{outputFileName}
+    >>>
+
+    output {
+      File finalReport = "~{outputFileName}"
+    }
+
+    meta {
+    output_meta: {
+      finalReport: "JSON file with merged results"
+    }
     }
 }

--- a/commands.txt
+++ b/commands.txt
@@ -1,303 +1,129 @@
-This section lists command(s) run by WORKFLOW workflow
- 
-### Run getChrCoefficient
+## Commands
+This section lists command(s) run by bamQC lite workflow
+
+* Running bamQC lite
+
+bamQC lite gets most of it's metrics from external tools (except the ones it generates by running CIGAR analysis on downsampled data). 
+It has fewer steps then the original bamQC but produces almost exact results.
+
+### Run samstats on unaltered inputs
 
 ```
-
- CHROM_LEN=$(samtools view -H ~{bamFile} | grep ^@SQ | grep -v _ | grep -w ~{chromosome} | cut -f 3 | sed 's/LN://')
- LARGEST=$(samtools view -H ~{bamFile} | grep ^@SQ | grep -v _ | cut -f 3 | sed 's/LN://' | sort -n | tail -n 1)
- echo | awk -v chrom_len=$CHROM_LEN -v largest=$LARGEST '{print int((chrom_len/largest + 0.1) * 10)/10}'
-
+    samtools stats ~{bamFile} -r  ~{referenceFile} > ~{filePrefix}.stats
 ```
 
-### Run bamQCMetrics
-  
-```
-  run_bam_qc.py \
-  -b ~{bamFile} \
-  -d ~{markDuplicates} \
-  --debug \
-  -i ~{normalInsertMax} \
-  -o ~{resultName} \
-  -r ~{refFasta} \
-  -t ~{refSizesBed} \
-  -T . \
-  -w ~{workflowVersion} \
-  ~{dsInput}
-```
-
-### Run collateResults
+### Run mosdepth to get coverage metrics
 
 ```
-  python3 <<CODE
-  import json
-  data = json.loads(open("~{bamQCMetricsResult}").read())
-  histogram = json.loads(open("~{histogram}").read())
-  data["coverage histogram"] = histogram
-  metadata = json.loads(open("~{metadata}").read())
-  for key in metadata.keys():
-      data[key] = metadata[key]
-  out = open("~{outputFileName}", "w")
-  json.dump(data, out, sort_keys=True)
-  out.close()
-  CODE
-```
-
-### Run cumulativeDistToHistogram
-
-```
-  python3 <<CODE
-  import csv, json
-  summary = open("~{summary}").readlines()
-  globalDist = open("~{globalDist}").readlines()
-  # read chromosome lengths from the summary
-  summaryReader = csv.reader(summary, delimiter="\t")
-  lengthByChr = {}
-  for row in summaryReader:
-      if row[0] == 'chrom' or row[0] == 'total':
-	  continue # skip initial header row, and final total row
-      lengthByChr[row[0]] = int(row[1])
-  chromosomes = sorted(lengthByChr.keys())
-  # read the cumulative distribution for each chromosome
-  globalReader = csv.reader(globalDist, delimiter="\t")
-  cumDist = {}
-  for k in chromosomes:
-      cumDist[k] = {}
-  for row in globalReader:
-      if row[0]=="total":
-	  continue
-      cumDist[row[0]][int(row[1])] = float(row[2])
-  # convert the cumulative distributions to non-cumulative and populate histogram
-  # if the input BAM is empty, chromosomes and histogram will also be empty
-  histogram = {}
-  for k in chromosomes:
-      depths = sorted(cumDist[k].keys())
-      dist = {}
-      for i in range(len(depths)-1):
-	  depth = depths[i]
-	  nextDepth = depths[i+1]
-	  dist[depth] = cumDist[k][depth] - cumDist[k][nextDepth]
-      maxDepth = max(depths)
-      dist[maxDepth] = cumDist[k][maxDepth]
-      # now find the number of loci at each depth of coverage to construct the histogram
-      for depth in depths:
-	  loci = int(round(dist[depth]*lengthByChr[k], 0))
-	  histogram[depth] = histogram.get(depth, 0) + loci
-  # if histogram is non-empty, fill in zero values for missing depths
-  for i in range(max(histogram.keys(), default=0)):
-      if i not in histogram:
-	  histogram[i] = 0
-  out = open("~{outFileName}", "w")
-  json.dump(histogram, out, sort_keys=True)
-  out.close()
-  CODE
-```
-
-### Run downsample 
-
-```
-    set -e
-    set -o pipefail
-    samtools view -b -h ~{bamFile} | \
-    ~{preDownsampleCommand} ~{downsampleCommand} \
-    samtools view -b > ~{resultName}
-```
-
-### downsampleRegion
-
-```
-    set -e
+    set -eo pipefail
     # ensure BAM file and index are symlinked to working directory
     ln -s ~{bamFile}
     ln -s ~{bamIndex}
-    samtools view -b -h ~{bamFileName} ~{region} > ~{resultName}
+    # run mosdepth
+    MOSDEPTH_PRECISION=8 mosdepth -x -n -t 3 bamqc ~{bamFileName} ~{"--by " + targetBed}
 ```
 
-### Run filter
+### Extract coverage histogram
 
 ```
-    set -e
-    set -o pipefail
-    samtools view -h -b -F 2304 -U ~{nonPrimaryReadsFile} ~{bamFile} | \
-    samtools view -h -b -F 4 -U ~{unmappedReadsFile} | \
-    samtools view -h -b -q ~{minQuality} -U ~{lowQualityReadsFile} \
-    > ~{resultName}
-    samtools view -c ~{bamFile} > ~{totalInputReadsFile}
-    samtools view -c ~{nonPrimaryReadsFile} > ~{totalNonPrimaryReadsFile}
-    samtools view -c ~{unmappedReadsFile} > ~{totalUnmappedReadsFile}
-    samtools view -c ~{lowQualityReadsFile} > ~{totalLowQualityReadsFile}
-    samtools index ~{bamFile} > ~{resultIndexName}
+        python3 <<CODE
+        import csv, json
+        summary = open("~{summary}").readlines()
+        globalDist = open("~{globalDist}").readlines()
+        # read chromosome lengths from the summary
+        summaryReader = csv.reader(summary, delimiter="\t")
+        lengthByChr = {}
+        for row in summaryReader:
+          if row[0] == 'chrom' or row[0] == 'total':
+            continue # skip initial header row, and final total row
+          if row[0].endswith('_region'):
+            continue # skip contigs from target file, if passed
+          lengthByChr[row[0]] = int(row[1])
+        chromosomes = sorted(lengthByChr.keys())
+        # read the cumulative distribution for each chromosome
+        globalReader = csv.reader(globalDist, delimiter="\t")
+        cumDist = {}
+        for k in chromosomes:
+          cumDist[k] = {}
+        for row in globalReader:
+          if row[0]=="total":
+            continue
+          cumDist[row[0]][int(row[1])] = float(row[2])
+        # convert the cumulative distributions to non-cumulative and populate histogram
+        # if the input BAM is empty, chromosomes and histogram will also be empty
+        histogram = {}
+        for k in chromosomes:
+          depths = sorted(cumDist[k].keys())
+          dist = {}
+          for i in range(len(depths)-1):
+            depth = depths[i]
+            nextDepth = depths[i+1]
+            dist[depth] = cumDist[k][depth] - cumDist[k][nextDepth]
+          maxDepth = max(depths)
+          dist[maxDepth] = cumDist[k][maxDepth]
+          # now find the number of loci at each depth of coverage to construct the histogram
+          for depth in depths:
+            loci = int(round(dist[depth]*lengthByChr[k], 0))
+            histogram[depth] = histogram.get(depth, 0) + loci
+        # if histogram is non-empty, fill in zero values for missing depths
+        for i in range(max(histogram.keys(), default=0)):
+          if i not in histogram:
+            histogram[i] = 0
+        out = open("~{outFileName}", "w")
+        json.dump(histogram, out, sort_keys=True)
+        out.close()
+        CODE
 ```
 
-### Run findDownsampleParams
+### Extract duplicate reads metrics with samblaster
+
+samblaster uses downsampled data piped into the tool. This allows having a much reduced filesystem footprint
+as there are no intermediate files generated in the process
 
 ```
-    python3 <<CODE
-    import json, math, sys
-    readsIn = ~{inputReads}
-    readsTarget = ~{targetReads}
-    precision = ~{precision}
-    print("Input reads param =", readsIn, file=sys.stderr)
-    print("Target reads param =", readsTarget, file=sys.stderr)
-    minReadsAbsolute = ~{minReadsAbsolute}
-    minReadsRelative = ~{minReadsRelative}
-    preDownsampleMultiplier = ~{preDSMultiplier}
-    if readsIn <= readsTarget:
-      # absolutely no downsampling
-      applyPreDownsample = False
-      applyDownsample = False
-      preDownsampleTarget = "no_pre_downsample"
-      downSampleTarget = "no_downsample"
-    elif readsIn < readsTarget * minReadsRelative or readsTarget < minReadsAbsolute:
-      # no predownsampling
-      applyPreDownsample = False
-      applyDownsample = True
-      preDownsampleTarget = "no_pre_downsample"
-      downSampleTarget = str(readsTarget)
-    else:
-      # predownsampling and downsampling
-      applyPreDownsample = True
-      applyDownsample = True
-      probability = (readsTarget * preDownsampleMultiplier)/readsIn
-      formatString = "{:0"+str(precision)+"d}"
-      preDownsampleTarget = formatString.format(int(math.floor(probability * 10**precision)))
-      downSampleTarget = str(readsTarget)
-    status = {
-      "pre_ds": applyPreDownsample,
-      "ds": applyDownsample
-    }
-    targets = {
-      "pre_ds": preDownsampleTarget,
-      "ds": downSampleTarget
-    }
-    statusFile = open("~{statusFile}", "w")
-    json.dump(status, statusFile)
-    statusFile.close()
-    targetFile = open("~{targetsFile}", "w")
-    json.dump(targets, targetFile)
-    targetFile.close()
-    CODE
+    set -euxo pipefail
+    samtools head -n ~{downsampleToReads} ~{bamFile} | \
+    samtools sort -n - | \
+    samtools fixmate -m -O SAM - - | \
+    samblaster --ignoreUnmated ~{additionalParam} --output /dev/null 2> >(tee "~{filePrefix}.markDuplicates.txt")
 ```
 
-### Run findDownsampleParamsMarkDup
+### For targeted sequencing, count reads on target with bedtools
 
 ```
-    python3 <<CODE
-    readsIn = ~{inputReads}
-    threshold = ~{threshold}
-    interval = ~{baseInterval}
-    start = ~{intervalStart} + 1 # start of sub-chromosome window, if needed; exclude telomeres
-    chromosomes = [line.strip() for line in open("~{chromosomesText}").readlines()]
-    customRegions = "~{customRegions}" # overrides other chromosome/interval parameters
-    ds = True # True if downsampling, false otherwise
-    end = None # end of window, if needed
-    if readsIn <= threshold:
-        ds = False # no downsampling
-    elif readsIn <= threshold*10:
-        pass # default to chr12 & chr13 =~ 8% of genome
-    elif readsIn <= threshold*10**2:
-        end = start + interval*10**3 - 1 # default 2*15 million base window ~ 1% of genome
-    elif readsIn <= threshold*10**3:
-        end = start + interval*10**2 - 1
-    elif readsIn <= threshold*10**4:
-        end = start + interval*10 - 1
-    else:
-        end = start + interval - 1
-    if ds:
-        status = "true"
-        if customRegions != "":
-            region = customRegions
-        elif end == None:
-            region = " ".join(chromosomes)
-        else:
-            regions = ["%s:%i-%i" % (chromosome, start, end) for chromosome in chromosomes ]
-            region = " ".join(regions)
-    else:
-        status = "false"
-        region = ""
-    outStatus = open("~{outputStatus}", "w")
-    print(status, file=outStatus)
-    outStatus.close()
-    outRegion = open("~{outputRegion}", "w")
-    print(region, file=outRegion)
-    outRegion.close()
-    CODE
+    bedtools intersect -a ~{inputBam} -b ~{targetBed} -u | samtools view -c | perl -pe 'chomp'
 ```
 
-### Run markDuplicates 
+### Count unique reads on downsampled data (needed for CIGAR metrics)
+
+CIGAR metrics are generated using downsampled bam, this step uses the same rate of downsampling
 
 ```
-    java -Xmx~{picardMaxMemMb}M \
-    -jar ${PICARD_ROOT}/picard.jar \
-    MarkDuplicates \
-    INPUT=~{bamFile} \
-    OUTPUT=~{outFileBam} \
-    VALIDATION_STRINGENCY=SILENT \
-    TMP_DIR=${PWD} \
-    METRICS_FILE=~{outFileText} \
-    OPTICAL_DUPLICATE_PIXEL_DISTANCE=~{opticalDuplicatePixelDistance}
+    samtools head -n ~{downsampleToReads} ~{inputBam} | samtools view -F 256 -q 30 -c | perl -pe 'chomp'
 ```
 
-### Run MergeFiles
- 
-```
-   set -euo pipefail
- 
-   gatk --java-options "-Xmx~{jobMemory - overhead}G" MergeSamFiles \
-   ~{sep=" " prefix("--INPUT=", bams)} \
-   --OUTPUT="~{outputFileName}~{suffix}.bam" \
-   --CREATE_INDEX=true \
-   --SORT_ORDER=coordinate \
-   --ASSUME_SORTED=false \
-   --USE_THREADING=true \
-   --VALIDATION_STRINGENCY=SILENT 
-  
-```
-
-### Run prefilter
+### Run bamQC lite which aggregates metrics into lane-level json report
 
 ```
- set -e
- set -o pipefail
- samtools view -b \
-      -F ~{filterFlags} \
-      ~{"-q " + minMapQuality} \
-      ~{filterAdditionalParams} \
-      ~{bamFile} \
-      ~{sep=" " intervals} > ~{resultName}
+        set -euxo pipefail
+        python3 ~{bamQClite} ~{"-b " + bamFile} \
+        -s ~{samstatsFile} \
+        -d ~{markDuplicatesStats} \
+        -c ~{histogram} \
+        -m ~{metadataJson} \
+        -w ~{workflowVersion} ~{"-tf " + targetBed} \
+        -r ~{referenceFileName} ~{"-S " + downsampleToReads} \
+        -o ~{outputFileName} \
+        -t ~{mosdepthSummary} ~{"-u " + uniqueReads} ~{"-ot " + readsOnTarget} 
 ```
 
-### Run runMosdepth 
+### Run merger script which will combine reports into call-ready report if there are multiple lanes
+
+This step will return lane-level report (exact copy of it's input) if there is one lane, but will
+combine metrics into call-ready report if there are multiple lanes
+
 
 ```
- set -eo pipefail
- # ensure BAM file and index are symlinked to working directory
- ln -s ~{bamFile}
- ln -s ~{bamIndex}
- # run mosdepth
- MOSDEPTH_PRECISION=8 mosdepth -x -n -t 3 bamqc ~{bamFileName}
-```
-
-### splitStringToArray
-
-```
-  set -euo pipefail
-  
-  echo "~{str}" | tr '~{lineSeparator}' '\n' | tr '~{recordSeparator}' '\t'
-```
-
-### Run updateMetadata
-
-```
-    python3 <<CODE
-    import json
-    metadata = json.loads(open("~{metadataJson}").read())
-    metadata["total input reads meta"] = ~{totalInputReads}
-    metadata["non-primary reads meta"] = ~{nonPrimaryReads}
-    metadata["unmapped reads meta"] = ~{unmappedReads}
-    metadata["low-quality reads meta"] = ~{lowQualityReads}
-    outFile = open("~{outFileName}", "w")
-    json.dump(metadata, outFile)
-    outFile.close()
-    CODE
+        set -euxo pipefail
+        python3 ~{bamQCmerger} -l ~{sep="," inputs} -o ~{outputFileName}
 ```

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -6,7 +6,5 @@ set -o pipefail
 cd $1
 
 module load jq
-# load python only if it's not already loaded
-module is-loaded python || module load python/3.10.4
-# remove the Picard header because it includes temporary paths
-find . -xtype f -exec jq 'del(.picard | .header)' {} \; | python3 -mjson.tool --sort-keys
+# extract the data for selected metrics
+find . -xtype f -exec  jq '. | with_entries(select(.key | contains("mean","average","reads","total")))' {} \; 

--- a/vidarrbuild.json
+++ b/vidarrbuild.json
@@ -2,7 +2,9 @@
     "names": [
         "bamqc_call_ready_by_tumor_group",
         "bamqc_call_ready",
-        "bamqc_lane_level"
+        "bamqc_lane_level",
+        "bamqc_lite_call_ready",
+        "bamqc_lite_lane_level"
     ],
     "wdl": "bamQC.wdl"
 }

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -105,7 +105,7 @@
                 {
                     "bam": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.subset.bam",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.bam",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -117,7 +117,7 @@
                     },
                     "bamIndex": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.subset.bam.bai",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.bam.bai",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -205,7 +205,7 @@
                 {
                     "bam": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.subset.bam",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.bam",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -217,7 +217,7 @@
                     },
                     "bamIndex": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.subset.bam.bai",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.bam.bai",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -305,7 +305,7 @@
                 {
                     "bam":{
                         "contents": {
-                        "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.bam",
+                        "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.bam",
                         "externalIds": [
                             {
                                 "id": "TEST",
@@ -317,7 +317,7 @@
                     },
                     "bamIndex": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.bam.bai",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.bam.bai",
                             "externalIds": [
                                 {
                                     "id": "TEST",

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -5,7 +5,7 @@
                 {
                     "bam": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_with_downsample/neat_5x_EX_hg19_chr21.bam",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/neat_Test01.bam",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -17,7 +17,7 @@
                     },
                     "bamIndex": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_with_downsample/neat_5x_EX_hg19_chr21.bam.bai",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/neat_Test01.bam.bai",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -30,124 +30,61 @@
                 }
             ],
             "bamQC.mode": "lane_level",
-            "bamQC.intervalsToParallelizeByString": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM",
+            "bamQC.bamQCMetrics.bamQClite": null,
             "bamQC.bamQCMetrics.jobMemory": null,
             "bamQC.bamQCMetrics.modules": null,
-            "bamQC.bamQCMetrics.normalInsertMax": null,
-            "bamQC.bamQCMetrics.refFasta": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19_random.fa",
-            "bamQC.bamQCMetrics.refSizesBed": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19.chrom.sizes.bed",
-            "bamQC.bamQCMetrics.threads": null,
+            "bamQC.bamQCMetrics.targetBed": null,
             "bamQC.bamQCMetrics.timeout": null,
-            "bamQC.bamQCMetrics.workflowVersion": "4.0.0_TEST",
-            "bamQC.collateResults.jobMemory": null,
-            "bamQC.collateResults.modules": null,
-            "bamQC.collateResults.threads": null,
-            "bamQC.collateResults.timeout": null,
+            "bamQC.bamQCMetrics.workflowVersion": "5.3.0",
             "bamQC.cumulativeDistToHistogram.jobMemory": null,
             "bamQC.cumulativeDistToHistogram.modules": null,
             "bamQC.cumulativeDistToHistogram.threads": null,
             "bamQC.cumulativeDistToHistogram.timeout": null,
-            "bamQC.downsample.downsampleSuffix": null,
-            "bamQC.downsample.jobMemory": null,
-            "bamQC.downsample.modules": null,
-            "bamQC.downsample.randomSeed": null,
-            "bamQC.downsample.threads": null,
-            "bamQC.downsample.timeout": null,
-            "bamQC.downsampleRegion.jobMemory": null,
-            "bamQC.downsampleRegion.modules": null,
-            "bamQC.downsampleRegion.threads": null,
-            "bamQC.downsampleRegion.timeout": null,
-            "bamQC.filter.jobMemory": null,
-            "bamQC.preFilter.minMemory": null,
-            "bamQC.filter.minQuality": null,
-            "bamQC.filter.modules": null,
-            "bamQC.filter.threads": null,
-            "bamQC.filter.timeout": null,
-            "bamQC.getChrCoefficient.memory": null,
-            "bamQC.getChrCoefficient.timeout": null,
-            "bamQC.getChrCoefficient.modules": "samtools/1.14",
-            "bamQC.preFilter.jobMemory": null,
-            "bamQC.preFilter.minMapQuality": null,
-            "bamQC.preFilter.filterFlags": null,
-            "bamQC.preFilter.filterAdditionalParams": null,
-            "bamQC.preFilter.modules": null,
-            "bamQC.preFilter.threads": null,
-            "bamQC.preFilter.timeout": null,
-            "bamQC.preFilter.scaleCoefficient": null,
-            "bamQC.findDownsampleParams.jobMemory": null,
-            "bamQC.findDownsampleParams.minReadsAbsolute": null,
-            "bamQC.findDownsampleParams.minReadsRelative": null,
-            "bamQC.findDownsampleParams.modules": null,
-            "bamQC.findDownsampleParams.preDSMultiplier": null,
-            "bamQC.findDownsampleParams.precision": null,
-            "bamQC.findDownsampleParams.targetReads": 20000,
-            "bamQC.findDownsampleParams.threads": null,
-            "bamQC.findDownsampleParams.timeout": null,
-            "bamQC.findDownsampleParamsMarkDup.baseInterval": null,
-            "bamQC.findDownsampleParamsMarkDup.chromosomes": null,
-            "bamQC.findDownsampleParamsMarkDup.customRegions": null,
-            "bamQC.findDownsampleParamsMarkDup.intervalStart": null,
-            "bamQC.findDownsampleParamsMarkDup.jobMemory": null,
-            "bamQC.findDownsampleParamsMarkDup.modules": null,
-            "bamQC.findDownsampleParamsMarkDup.threads": null,
-            "bamQC.findDownsampleParamsMarkDup.threshold": null,
-            "bamQC.findDownsampleParamsMarkDup.timeout": null,
-            "bamQC.indexBamFile.jobMemory": null,
-            "bamQC.indexBamFile.modules": null,
-            "bamQC.indexBamFile.threads": null,
-            "bamQC.indexBamFile.timeout": null,
+            "bamQC.downsampleToReads": 500000,
+            "bamQC.getUniqueReadsCount.jobMemory": null,
+            "bamQC.getUniqueReadsCount.modules": null,
+            "bamQC.getUniqueReadsCount.timeout": null,
+            "bamQC.markDuplicates.additionalParam": null,
             "bamQC.markDuplicates.jobMemory": null,
             "bamQC.markDuplicates.modules": null,
-            "bamQC.markDuplicates.opticalDuplicatePixelDistance": null,
-            "bamQC.markDuplicates.picardMaxMemMb": null,
+            "bamQC.markDuplicates.samblaster": null,
             "bamQC.markDuplicates.threads": null,
             "bamQC.markDuplicates.timeout": null,
+            "bamQC.mergeReports.bamQCmerger": null,
+            "bamQC.mergeReports.jobMemory": null,
+            "bamQC.mergeReports.modules": null,
+            "bamQC.mergeReports.timeout": null,
             "bamQC.metadata": {
-                "donor": "Xenomorph",
-                "group id": "Weyland-Yutani",
-                "library design": "WY-1001",
-                "tissue origin": "LV-426",
-                "tissue type": "Claw fragment"
+               "donor": "Xenomorph",
+               "group id": "Weyland-Yutani",
+               "library design": "WY-1001",
+               "tissue origin": "LV-426",
+               "tissue type": "Claw fragment"
             },
-            "bamQC.outputFileNamePrefix": "test_with_downsample",
+            "bamQC.outputFileNamePrefix": "LANE_LEVEL",
+            "bamQC.reference": "hg19",
+            "bamQC.runBedtools": null,
+            "bamQC.runBedtoolsIntersect.jobMemory": null,
+            "bamQC.runBedtoolsIntersect.modules": null,
+            "bamQC.runBedtoolsIntersect.timeout": null,
             "bamQC.runMosdepth.jobMemory": null,
             "bamQC.runMosdepth.modules": null,
-            "bamQC.runMosdepth.threads": null,
             "bamQC.runMosdepth.timeout": null,
-            "bamQC.mergeFiles.cores": null,
-            "bamQC.mergeFiles.modules": null,
-            "bamQC.mergeFiles.suffix": null,
-            "bamQC.mergeFiles.jobMemory": null,
-            "bamQC.mergeFiles.overhead": null,
-            "bamQC.mergeFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.jobMemory": null,
-            "bamQC.mergeSplitByIntervalFiles.overhead": null,
-            "bamQC.mergeSplitByIntervalFiles.suffix": null,
-            "bamQC.mergeSplitByIntervalFiles.cores": null,
-            "bamQC.mergeSplitByIntervalFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.modules": null,
-            "bamQC.splitStringToArray.cores": null,
-            "bamQC.splitStringToArray.lineSeparator": null,
-            "bamQC.splitStringToArray.jobMemory": null,
-            "bamQC.splitStringToArray.recordSeparator": null,
-            "bamQC.splitStringToArray.timeout": null,
-            "bamQC.splitStringToArray.modules": null,
-            "bamQC.updateMetadata.jobMemory": null,
-            "bamQC.updateMetadata.modules": null,
-            "bamQC.updateMetadata.threads": null,
-            "bamQC.updateMetadata.timeout": null
+            "bamQC.samstats.jobMemory": null,
+            "bamQC.samstats.timeout": null,
+            "bamQC.targetBed": null
         },
-        "description": "bamQC workflow test",
+        "description": "bamQC lane-level test",
         "engineArguments": {
            "write_to_cache": false,
            "read_from_cache": false
         },
-        "id": "bamQC_test_with_downsample",
+        "id": "test_lane_level",
         "metadata": {
             "bamQC.result": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamQC_bamQC_test_with_downsample_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamQC_test_lane_level_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -157,7 +94,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.1.1/bamQC_test_with_downsample.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.3.0/bamQC_test_lane_level.metrics",
                 "type": "script"
             }
         ]
@@ -168,7 +105,7 @@
                 {
                     "bam": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_without_downsample/neat_5x_EX_hg19_chr21.bam",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.subset.bam",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -180,7 +117,7 @@
                     },
                     "bamIndex": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_without_downsample/neat_5x_EX_hg19_chr21.bam.bai",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.subset.bam.bai",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -193,96 +130,30 @@
                 }
             ],
             "bamQC.mode": "lane_level",
-            "bamQC.intervalsToParallelizeByString": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM",
-            "bamQC.mergeFiles.cores": null,
-            "bamQC.mergeFiles.modules": null,
-            "bamQC.mergeFiles.suffix": null,
-            "bamQC.mergeFiles.jobMemory": null,
-            "bamQC.mergeFiles.overhead": null,
-            "bamQC.mergeFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.jobMemory": null,
-            "bamQC.mergeSplitByIntervalFiles.overhead": null,
-            "bamQC.mergeSplitByIntervalFiles.suffix": null,
-            "bamQC.mergeSplitByIntervalFiles.cores": null,
-            "bamQC.mergeSplitByIntervalFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.modules": null,
-            "bamQC.splitStringToArray.cores": null,
-            "bamQC.splitStringToArray.lineSeparator": null,
-            "bamQC.splitStringToArray.jobMemory": null,
-            "bamQC.splitStringToArray.recordSeparator": null,
-            "bamQC.splitStringToArray.timeout": null,
-            "bamQC.splitStringToArray.modules": null,
+            "bamQC.bamQCMetrics.bamQClite": null,
             "bamQC.bamQCMetrics.jobMemory": null,
             "bamQC.bamQCMetrics.modules": null,
-            "bamQC.bamQCMetrics.normalInsertMax": null,
-            "bamQC.bamQCMetrics.refFasta": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19_random.fa",
-            "bamQC.bamQCMetrics.refSizesBed": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19.chrom.sizes.bed",
-            "bamQC.bamQCMetrics.threads": null,
+            "bamQC.bamQCMetrics.targetBed": null,
             "bamQC.bamQCMetrics.timeout": null,
-            "bamQC.bamQCMetrics.workflowVersion": "4.0.0_TEST",
-            "bamQC.collateResults.jobMemory": null,
-            "bamQC.collateResults.modules": null,
-            "bamQC.collateResults.threads": null,
-            "bamQC.collateResults.timeout": null,
+            "bamQC.bamQCMetrics.workflowVersion": "5.3.0",
             "bamQC.cumulativeDistToHistogram.jobMemory": null,
             "bamQC.cumulativeDistToHistogram.modules": null,
             "bamQC.cumulativeDistToHistogram.threads": null,
             "bamQC.cumulativeDistToHistogram.timeout": null,
-            "bamQC.downsample.downsampleSuffix": null,
-            "bamQC.downsample.jobMemory": null,
-            "bamQC.downsample.modules": null,
-            "bamQC.downsample.randomSeed": null,
-            "bamQC.downsample.threads": null,
-            "bamQC.downsample.timeout": null,
-            "bamQC.downsampleRegion.jobMemory": null,
-            "bamQC.downsampleRegion.modules": null,
-            "bamQC.downsampleRegion.threads": null,
-            "bamQC.downsampleRegion.timeout": null,
-            "bamQC.filter.jobMemory": null,
-            "bamQC.preFilter.minMemory": null,
-            "bamQC.filter.minQuality": null,
-            "bamQC.filter.modules": null,
-            "bamQC.filter.threads": null,
-            "bamQC.filter.timeout": null,
-            "bamQC.getChrCoefficient.memory": null,
-            "bamQC.getChrCoefficient.timeout": null,
-            "bamQC.getChrCoefficient.modules": "samtools/1.14",
-            "bamQC.preFilter.jobMemory": null,
-            "bamQC.preFilter.minMapQuality": null,
-            "bamQC.preFilter.filterFlags": null,
-            "bamQC.preFilter.filterAdditionalParams": null,
-            "bamQC.preFilter.modules": null,
-            "bamQC.preFilter.threads": null,
-            "bamQC.preFilter.timeout": null,
-            "bamQC.preFilter.scaleCoefficient": null,
-            "bamQC.findDownsampleParams.jobMemory": null,
-            "bamQC.findDownsampleParams.minReadsAbsolute": null,
-            "bamQC.findDownsampleParams.minReadsRelative": null,
-            "bamQC.findDownsampleParams.modules": null,
-            "bamQC.findDownsampleParams.preDSMultiplier": null,
-            "bamQC.findDownsampleParams.precision": null,
-            "bamQC.findDownsampleParams.targetReads": 100000,
-            "bamQC.findDownsampleParams.threads": null,
-            "bamQC.findDownsampleParams.timeout": null,
-            "bamQC.findDownsampleParamsMarkDup.baseInterval": null,
-            "bamQC.findDownsampleParamsMarkDup.chromosomes": null,
-            "bamQC.findDownsampleParamsMarkDup.customRegions": null,
-            "bamQC.findDownsampleParamsMarkDup.intervalStart": null,
-            "bamQC.findDownsampleParamsMarkDup.jobMemory": null,
-            "bamQC.findDownsampleParamsMarkDup.modules": null,
-            "bamQC.findDownsampleParamsMarkDup.threads": null,
-            "bamQC.findDownsampleParamsMarkDup.threshold": null,
-            "bamQC.findDownsampleParamsMarkDup.timeout": null,
-            "bamQC.indexBamFile.jobMemory": null,
-            "bamQC.indexBamFile.modules": null,
-            "bamQC.indexBamFile.threads": null,
-            "bamQC.indexBamFile.timeout": null,
+            "bamQC.downsampleToReads": 500000,
+            "bamQC.getUniqueReadsCount.jobMemory": null,
+            "bamQC.getUniqueReadsCount.modules": null,
+            "bamQC.getUniqueReadsCount.timeout": null,
+            "bamQC.markDuplicates.additionalParam": null,
             "bamQC.markDuplicates.jobMemory": null,
             "bamQC.markDuplicates.modules": null,
-            "bamQC.markDuplicates.opticalDuplicatePixelDistance": null,
-            "bamQC.markDuplicates.picardMaxMemMb": null,
+            "bamQC.markDuplicates.samblaster": null,
             "bamQC.markDuplicates.threads": null,
             "bamQC.markDuplicates.timeout": null,
+            "bamQC.mergeReports.bamQCmerger": null,
+            "bamQC.mergeReports.jobMemory": null,
+            "bamQC.mergeReports.modules": null,
+            "bamQC.mergeReports.timeout": null,
             "bamQC.metadata": {
                 "donor": "Xenomorph",
                 "group id": "Weyland-Yutani",
@@ -290,27 +161,30 @@
                 "tissue origin": "LV-426",
                 "tissue type": "Claw fragment"
             },
-            "bamQC.outputFileNamePrefix": "test_without_downsample",
+            "bamQC.outputFileNamePrefix": "TEST01",
+            "bamQC.reference": "hg19",
+            "bamQC.runBedtools": null,
+            "bamQC.runBedtoolsIntersect.jobMemory": null,
+            "bamQC.runBedtoolsIntersect.modules": null,
+            "bamQC.runBedtoolsIntersect.timeout": null,
             "bamQC.runMosdepth.jobMemory": null,
             "bamQC.runMosdepth.modules": null,
-            "bamQC.runMosdepth.threads": null,
             "bamQC.runMosdepth.timeout": null,
-            "bamQC.updateMetadata.jobMemory": null,
-            "bamQC.updateMetadata.modules": null,
-            "bamQC.updateMetadata.threads": null,
-            "bamQC.updateMetadata.timeout": null
+            "bamQC.samstats.jobMemory": null,
+            "bamQC.samstats.timeout": null,
+            "bamQC.targetBed": null
         },
-        "description": "bamQC workflow test",
+        "description": "bamQC workflow 01 test",
         "engineArguments": {
            "write_to_cache": false,
            "read_from_cache": false
         },
-        "id": "bamQC_test_without_downsample",
+        "id": "bamQC_test_01",
         "metadata": {
             "bamQC.result": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamQC_bamQC_test_without_downsample_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamQC_bamQC_test_01_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -320,7 +194,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.1.1/bamQC_test_without_downsample.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.3.0/bamQC_test_01.metrics",
                 "type": "script"
             }
         ]
@@ -331,7 +205,7 @@
                 {
                     "bam": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_CRE/SWID_15949654_CRE_0002_Pb_R_PE_409_WG_200124_A00469_0077_BHNGLTDSXX_GAGACGAT-TAACCGGT_L002_001.annotated.subset.bam",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.subset.bam",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -343,7 +217,7 @@
                     },
                     "bamIndex": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_CRE/SWID_15949654_CRE_0002_Pb_R_PE_409_WG_200124_A00469_0077_BHNGLTDSXX_GAGACGAT-TAACCGGT_L002_001.annotated.subset.bam.bai",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.subset.bam.bai",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -356,96 +230,30 @@
                 }
             ],
             "bamQC.mode": "lane_level",
-            "bamQC.intervalsToParallelizeByString": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM",
-            "bamQC.mergeFiles.cores": null,
-            "bamQC.mergeFiles.modules": null,
-            "bamQC.mergeFiles.suffix": null,
-            "bamQC.mergeFiles.jobMemory": null,
-            "bamQC.mergeFiles.overhead": null,
-            "bamQC.mergeFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.jobMemory": null,
-            "bamQC.mergeSplitByIntervalFiles.overhead": null,
-            "bamQC.mergeSplitByIntervalFiles.suffix": null,
-            "bamQC.mergeSplitByIntervalFiles.cores": null,
-            "bamQC.mergeSplitByIntervalFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.modules": null,
-            "bamQC.splitStringToArray.cores": null,
-            "bamQC.splitStringToArray.lineSeparator": null,
-            "bamQC.splitStringToArray.jobMemory": null,
-            "bamQC.splitStringToArray.recordSeparator": null,
-            "bamQC.splitStringToArray.timeout": null,
-            "bamQC.splitStringToArray.modules": null,
+            "bamQC.bamQCMetrics.bamQClite": null,
             "bamQC.bamQCMetrics.jobMemory": null,
             "bamQC.bamQCMetrics.modules": null,
-            "bamQC.bamQCMetrics.normalInsertMax": null,
-            "bamQC.bamQCMetrics.refFasta": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19_random.fa",
-            "bamQC.bamQCMetrics.refSizesBed": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19.chrom.sizes.bed",
-            "bamQC.bamQCMetrics.threads": null,
+            "bamQC.bamQCMetrics.targetBed": null,
             "bamQC.bamQCMetrics.timeout": null,
-            "bamQC.bamQCMetrics.workflowVersion": "4.0.0_TEST",
-            "bamQC.collateResults.jobMemory": null,
-            "bamQC.collateResults.modules": null,
-            "bamQC.collateResults.threads": null,
-            "bamQC.collateResults.timeout": null,
+            "bamQC.bamQCMetrics.workflowVersion": "5.3.0",
             "bamQC.cumulativeDistToHistogram.jobMemory": null,
             "bamQC.cumulativeDistToHistogram.modules": null,
             "bamQC.cumulativeDistToHistogram.threads": null,
             "bamQC.cumulativeDistToHistogram.timeout": null,
-            "bamQC.downsample.downsampleSuffix": null,
-            "bamQC.downsample.jobMemory": null,
-            "bamQC.downsample.modules": null,
-            "bamQC.downsample.randomSeed": null,
-            "bamQC.downsample.threads": null,
-            "bamQC.downsample.timeout": null,
-            "bamQC.downsampleRegion.jobMemory": null,
-            "bamQC.downsampleRegion.modules": null,
-            "bamQC.downsampleRegion.threads": null,
-            "bamQC.downsampleRegion.timeout": null,
-            "bamQC.filter.jobMemory": null,
-            "bamQC.preFilter.minMemory": null,
-            "bamQC.filter.minQuality": null,
-            "bamQC.filter.modules": null,
-            "bamQC.filter.threads": null,
-            "bamQC.filter.timeout": null,
-            "bamQC.getChrCoefficient.memory": null,
-            "bamQC.getChrCoefficient.timeout": null,
-            "bamQC.getChrCoefficient.modules": "samtools/1.14",
-            "bamQC.preFilter.jobMemory": null,
-            "bamQC.preFilter.minMapQuality": null,
-            "bamQC.preFilter.filterFlags": null,
-            "bamQC.preFilter.filterAdditionalParams": null,
-            "bamQC.preFilter.modules": null,
-            "bamQC.preFilter.threads": null,
-            "bamQC.preFilter.timeout": null,
-            "bamQC.preFilter.scaleCoefficient": null,
-            "bamQC.findDownsampleParams.jobMemory": null,
-            "bamQC.findDownsampleParams.minReadsAbsolute": null,
-            "bamQC.findDownsampleParams.minReadsRelative": null,
-            "bamQC.findDownsampleParams.modules": null,
-            "bamQC.findDownsampleParams.preDSMultiplier": null,
-            "bamQC.findDownsampleParams.precision": null,
-            "bamQC.findDownsampleParams.targetReads": 100000,
-            "bamQC.findDownsampleParams.threads": null,
-            "bamQC.findDownsampleParams.timeout": null,
-            "bamQC.findDownsampleParamsMarkDup.baseInterval": null,
-            "bamQC.findDownsampleParamsMarkDup.chromosomes": null,
-            "bamQC.findDownsampleParamsMarkDup.customRegions": null,
-            "bamQC.findDownsampleParamsMarkDup.intervalStart": null,
-            "bamQC.findDownsampleParamsMarkDup.jobMemory": null,
-            "bamQC.findDownsampleParamsMarkDup.modules": null,
-            "bamQC.findDownsampleParamsMarkDup.threads": null,
-            "bamQC.findDownsampleParamsMarkDup.threshold": 100000,
-            "bamQC.findDownsampleParamsMarkDup.timeout": null,
-            "bamQC.indexBamFile.jobMemory": null,
-            "bamQC.indexBamFile.modules": null,
-            "bamQC.indexBamFile.threads": null,
-            "bamQC.indexBamFile.timeout": null,
+            "bamQC.downsampleToReads": 500000,
+            "bamQC.getUniqueReadsCount.jobMemory": null,
+            "bamQC.getUniqueReadsCount.modules": null,
+            "bamQC.getUniqueReadsCount.timeout": null,
+            "bamQC.markDuplicates.additionalParam": null,
             "bamQC.markDuplicates.jobMemory": null,
             "bamQC.markDuplicates.modules": null,
-            "bamQC.markDuplicates.opticalDuplicatePixelDistance": null,
-            "bamQC.markDuplicates.picardMaxMemMb": null,
+            "bamQC.markDuplicates.samblaster": null,
             "bamQC.markDuplicates.threads": null,
             "bamQC.markDuplicates.timeout": null,
+            "bamQC.mergeReports.bamQCmerger": null,
+            "bamQC.mergeReports.jobMemory": null,
+            "bamQC.mergeReports.modules": null,
+            "bamQC.mergeReports.timeout": null,
             "bamQC.metadata": {
                 "donor": "Xenomorph",
                 "group id": "Weyland-Yutani",
@@ -453,27 +261,30 @@
                 "tissue origin": "LV-426",
                 "tissue type": "Claw fragment"
             },
-            "bamQC.outputFileNamePrefix": "test_CRE",
+            "bamQC.outputFileNamePrefix": "TARGETED",
+            "bamQC.reference": "hg19",
+            "bamQC.runBedtools": true,
+            "bamQC.runBedtoolsIntersect.jobMemory": null,
+            "bamQC.runBedtoolsIntersect.modules": null,
+            "bamQC.runBedtoolsIntersect.timeout": null,
             "bamQC.runMosdepth.jobMemory": null,
             "bamQC.runMosdepth.modules": null,
-            "bamQC.runMosdepth.threads": null,
             "bamQC.runMosdepth.timeout": null,
-            "bamQC.updateMetadata.jobMemory": null,
-            "bamQC.updateMetadata.modules": null,
-            "bamQC.updateMetadata.threads": null,
-            "bamQC.updateMetadata.timeout": null
+            "bamQC.samstats.jobMemory": null,
+            "bamQC.samstats.timeout": null,
+            "bamQC.targetBed": "/.mounts/labs/gsi/testdata/bamqc/input_data/intervals/hg19_knownGenes.chr21.bed"
         },
-        "description": "bamQC workflow test",
+        "description": "bamQC workflow test targeted",
         "engineArguments": {
            "write_to_cache": false,
            "read_from_cache": false
         },
-        "id": "bamQC_test_CRE",
+        "id": "bamQC_test_targeted",
         "metadata": {
             "bamQC.result": {
                 "contents": [
                     {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamQC_bamQC_test_CRE_@JENKINSID@"
+                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamQC_bamQC_test_targeted_@JENKINSID@"
                     }
                 ],
                 "type": "ALL"
@@ -483,333 +294,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.1.1/bamQC_test_CRE.metrics",
-                "type": "script"
-            }
-        ]
-    },
-    {
-        "arguments": {
-            "bamQC.inputGroups": [
-                {
-                    "bam": {
-                        "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_CRE/SWID_15949654_CRE_0002_Pb_R_PE_409_WG_200124_A00469_0077_BHNGLTDSXX_GAGACGAT-TAACCGGT_L002_001.annotated.subset.bam",
-                            "externalIds": [
-                                {
-                                    "id": "TEST",
-                                    "provider": "TEST"
-                                }
-                            ]
-                        },
-                        "type": "EXTERNAL"
-                    },
-                    "bamIndex": {
-                        "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_CRE/SWID_15949654_CRE_0002_Pb_R_PE_409_WG_200124_A00469_0077_BHNGLTDSXX_GAGACGAT-TAACCGGT_L002_001.annotated.subset.bam.bai",
-                            "externalIds": [
-                                {
-                                    "id": "TEST",
-                                    "provider": "TEST"
-                                }
-                            ]
-                        },
-                        "type": "EXTERNAL"
-                    }
-                }
-            ],
-            "bamQC.mode": "lane_level",
-            "bamQC.intervalsToParallelizeByString": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM",
-            "bamQC.mergeFiles.cores": null,
-            "bamQC.mergeFiles.modules": null,
-            "bamQC.mergeFiles.suffix": null,
-            "bamQC.mergeFiles.jobMemory": null,
-            "bamQC.mergeFiles.overhead": null,
-            "bamQC.mergeFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.jobMemory": null,
-            "bamQC.mergeSplitByIntervalFiles.overhead": null,
-            "bamQC.mergeSplitByIntervalFiles.suffix": null,
-            "bamQC.mergeSplitByIntervalFiles.cores": null,
-            "bamQC.mergeSplitByIntervalFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.modules": null,
-            "bamQC.splitStringToArray.cores": null,
-            "bamQC.splitStringToArray.lineSeparator": null,
-            "bamQC.splitStringToArray.jobMemory": null,
-            "bamQC.splitStringToArray.recordSeparator": null,
-            "bamQC.splitStringToArray.timeout": null,
-            "bamQC.splitStringToArray.modules": null,
-            "bamQC.bamQCMetrics.jobMemory": null,
-            "bamQC.bamQCMetrics.modules": null,
-            "bamQC.bamQCMetrics.normalInsertMax": null,
-            "bamQC.bamQCMetrics.refFasta": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19_random.fa",
-            "bamQC.bamQCMetrics.refSizesBed": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19.chrom.sizes.bed",
-            "bamQC.bamQCMetrics.threads": null,
-            "bamQC.bamQCMetrics.timeout": null,
-            "bamQC.bamQCMetrics.workflowVersion": "4.0.0_TEST",
-            "bamQC.collateResults.jobMemory": null,
-            "bamQC.collateResults.modules": null,
-            "bamQC.collateResults.threads": null,
-            "bamQC.collateResults.timeout": null,
-            "bamQC.cumulativeDistToHistogram.jobMemory": null,
-            "bamQC.cumulativeDistToHistogram.modules": null,
-            "bamQC.cumulativeDistToHistogram.threads": null,
-            "bamQC.cumulativeDistToHistogram.timeout": null,
-            "bamQC.downsample.downsampleSuffix": null,
-            "bamQC.downsample.jobMemory": null,
-            "bamQC.downsample.modules": null,
-            "bamQC.downsample.randomSeed": null,
-            "bamQC.downsample.threads": null,
-            "bamQC.downsample.timeout": null,
-            "bamQC.downsampleRegion.jobMemory": null,
-            "bamQC.downsampleRegion.modules": null,
-            "bamQC.downsampleRegion.threads": null,
-            "bamQC.downsampleRegion.timeout": null,
-            "bamQC.filter.jobMemory": null,
-            "bamQC.preFilter.minMemory": null,
-            "bamQC.filter.minQuality": null,
-            "bamQC.filter.modules": null,
-            "bamQC.filter.threads": null,
-            "bamQC.filter.timeout": null,
-            "bamQC.getChrCoefficient.memory": null,
-            "bamQC.getChrCoefficient.timeout": null,
-            "bamQC.getChrCoefficient.modules": "samtools/1.14",
-            "bamQC.preFilter.jobMemory": null,
-            "bamQC.preFilter.minMapQuality": null,
-            "bamQC.preFilter.filterFlags": null,
-            "bamQC.preFilter.filterAdditionalParams": null,
-            "bamQC.preFilter.modules": null,
-            "bamQC.preFilter.threads": null,
-            "bamQC.preFilter.timeout": null,
-            "bamQC.preFilter.scaleCoefficient": null,
-            "bamQC.findDownsampleParams.jobMemory": null,
-            "bamQC.findDownsampleParams.minReadsAbsolute": null,
-            "bamQC.findDownsampleParams.minReadsRelative": null,
-            "bamQC.findDownsampleParams.modules": null,
-            "bamQC.findDownsampleParams.preDSMultiplier": null,
-            "bamQC.findDownsampleParams.precision": null,
-            "bamQC.findDownsampleParams.targetReads": 100000,
-            "bamQC.findDownsampleParams.threads": null,
-            "bamQC.findDownsampleParams.timeout": null,
-            "bamQC.findDownsampleParamsMarkDup.baseInterval": null,
-            "bamQC.findDownsampleParamsMarkDup.chromosomes": null,
-            "bamQC.findDownsampleParamsMarkDup.customRegions": "chr1:100000001-200000000 chr2:100000001-200000000",
-            "bamQC.findDownsampleParamsMarkDup.intervalStart": null,
-            "bamQC.findDownsampleParamsMarkDup.jobMemory": null,
-            "bamQC.findDownsampleParamsMarkDup.modules": null,
-            "bamQC.findDownsampleParamsMarkDup.threads": null,
-            "bamQC.findDownsampleParamsMarkDup.threshold": 100000,
-            "bamQC.findDownsampleParamsMarkDup.timeout": null,
-            "bamQC.indexBamFile.jobMemory": null,
-            "bamQC.indexBamFile.modules": null,
-            "bamQC.indexBamFile.threads": null,
-            "bamQC.indexBamFile.timeout": null,
-            "bamQC.markDuplicates.jobMemory": null,
-            "bamQC.markDuplicates.modules": null,
-            "bamQC.markDuplicates.opticalDuplicatePixelDistance": null,
-            "bamQC.markDuplicates.picardMaxMemMb": null,
-            "bamQC.markDuplicates.threads": null,
-            "bamQC.markDuplicates.timeout": null,
-            "bamQC.metadata": {
-                "donor": "Xenomorph",
-                "group id": "Weyland-Yutani",
-                "library design": "WY-1001",
-                "tissue origin": "LV-426",
-                "tissue type": "Claw fragment"
-            },
-            "bamQC.outputFileNamePrefix": "test_CRE_custom",
-            "bamQC.runMosdepth.jobMemory": null,
-            "bamQC.runMosdepth.modules": null,
-            "bamQC.runMosdepth.threads": null,
-            "bamQC.runMosdepth.timeout": null,
-            "bamQC.updateMetadata.jobMemory": null,
-            "bamQC.updateMetadata.modules": null,
-            "bamQC.updateMetadata.threads": null,
-            "bamQC.updateMetadata.timeout": null
-        },
-        "description": "bamQC workflow test",
-        "engineArguments": {
-           "write_to_cache": false,
-           "read_from_cache": false
-        },
-        "id": "bamQC_test_CRE_custom",
-        "metadata": {
-            "bamQC.result": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamQC_bamQC_test_CRE_custom_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            }
-        },
-        "validators": [
-            {
-                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
-                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.1.1/bamQC_test_CRE_custom.metrics",
-                "type": "script"
-            }
-        ]
-    },
-    {
-        "arguments": {
-            "bamQC.inputGroups": [
-                {
-                    "bam": {
-                        "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_empty_input/neat_5x_EX_hg19_chr21.bam",
-                            "externalIds": [
-                                {
-                                    "id": "TEST",
-                                    "provider": "TEST"
-                                }
-                            ]
-                        },
-                        "type": "EXTERNAL"
-                    },
-                    "bamIndex": {
-                        "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_empty_input/neat_5x_EX_hg19_chr21.bam.bai",
-                            "externalIds": [
-                                {
-                                    "id": "TEST",
-                                    "provider": "TEST"
-                                }
-                            ]
-                        },
-                        "type": "EXTERNAL"
-                    }
-                }
-            ],
-            "bamQC.mode": "call_ready",
-            "bamQC.intervalsToParallelizeByString": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM",
-            "bamQC.mergeFiles.cores": null,
-            "bamQC.mergeFiles.modules": null,
-            "bamQC.mergeFiles.suffix": null,
-            "bamQC.mergeFiles.jobMemory": null,
-            "bamQC.mergeFiles.overhead": null,
-            "bamQC.mergeFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.jobMemory": null,
-            "bamQC.mergeSplitByIntervalFiles.overhead": null,
-            "bamQC.mergeSplitByIntervalFiles.suffix": null,
-            "bamQC.mergeSplitByIntervalFiles.cores": null,
-            "bamQC.mergeSplitByIntervalFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.modules": null,
-            "bamQC.splitStringToArray.cores": null,
-            "bamQC.splitStringToArray.lineSeparator": null,
-            "bamQC.splitStringToArray.jobMemory": null,
-            "bamQC.splitStringToArray.recordSeparator": null,
-            "bamQC.splitStringToArray.timeout": null,
-            "bamQC.splitStringToArray.modules": null,
-            "bamQC.bamQCMetrics.jobMemory": null,
-            "bamQC.bamQCMetrics.modules": null,
-            "bamQC.bamQCMetrics.normalInsertMax": null,
-            "bamQC.bamQCMetrics.refFasta": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19_random.fa",
-            "bamQC.bamQCMetrics.refSizesBed": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19.chrom.sizes.bed",
-            "bamQC.bamQCMetrics.threads": null,
-            "bamQC.bamQCMetrics.timeout": null,
-            "bamQC.bamQCMetrics.workflowVersion": "4.0.0_TEST",
-            "bamQC.collateResults.jobMemory": null,
-            "bamQC.collateResults.modules": null,
-            "bamQC.collateResults.threads": null,
-            "bamQC.collateResults.timeout": null,
-            "bamQC.cumulativeDistToHistogram.jobMemory": null,
-            "bamQC.cumulativeDistToHistogram.modules": null,
-            "bamQC.cumulativeDistToHistogram.threads": null,
-            "bamQC.cumulativeDistToHistogram.timeout": null,
-            "bamQC.downsample.downsampleSuffix": null,
-            "bamQC.downsample.jobMemory": null,
-            "bamQC.downsample.modules": null,
-            "bamQC.downsample.randomSeed": null,
-            "bamQC.downsample.threads": null,
-            "bamQC.downsample.timeout": null,
-            "bamQC.downsampleRegion.jobMemory": null,
-            "bamQC.downsampleRegion.modules": null,
-            "bamQC.downsampleRegion.threads": null,
-            "bamQC.downsampleRegion.timeout": null,
-            "bamQC.filter.jobMemory": null,
-            "bamQC.preFilter.minMemory": null,
-            "bamQC.filter.minQuality": null,
-            "bamQC.filter.modules": null,
-            "bamQC.filter.threads": null,
-            "bamQC.filter.timeout": null,
-            "bamQC.getChrCoefficient.memory": null,
-            "bamQC.getChrCoefficient.timeout": null,
-            "bamQC.getChrCoefficient.modules": "samtools/1.14",
-            "bamQC.preFilter.jobMemory": null,
-            "bamQC.preFilter.minMapQuality": null,
-            "bamQC.preFilter.filterFlags": null,
-            "bamQC.preFilter.filterAdditionalParams": null,
-            "bamQC.preFilter.modules": null,
-            "bamQC.preFilter.threads": null,
-            "bamQC.preFilter.timeout": null,
-            "bamQC.preFilter.scaleCoefficient": null,
-            "bamQC.findDownsampleParams.jobMemory": null,
-            "bamQC.findDownsampleParams.minReadsAbsolute": null,
-            "bamQC.findDownsampleParams.minReadsRelative": null,
-            "bamQC.findDownsampleParams.modules": null,
-            "bamQC.findDownsampleParams.preDSMultiplier": null,
-            "bamQC.findDownsampleParams.precision": null,
-            "bamQC.findDownsampleParams.targetReads": 20000,
-            "bamQC.findDownsampleParams.threads": null,
-            "bamQC.findDownsampleParams.timeout": null,
-            "bamQC.findDownsampleParamsMarkDup.baseInterval": null,
-            "bamQC.findDownsampleParamsMarkDup.chromosomes": null,
-            "bamQC.findDownsampleParamsMarkDup.customRegions": null,
-            "bamQC.findDownsampleParamsMarkDup.intervalStart": null,
-            "bamQC.findDownsampleParamsMarkDup.jobMemory": null,
-            "bamQC.findDownsampleParamsMarkDup.modules": null,
-            "bamQC.findDownsampleParamsMarkDup.threads": null,
-            "bamQC.findDownsampleParamsMarkDup.threshold": null,
-            "bamQC.findDownsampleParamsMarkDup.timeout": null,
-            "bamQC.indexBamFile.jobMemory": null,
-            "bamQC.indexBamFile.modules": null,
-            "bamQC.indexBamFile.threads": null,
-            "bamQC.indexBamFile.timeout": null,
-            "bamQC.markDuplicates.jobMemory": null,
-            "bamQC.markDuplicates.modules": null,
-            "bamQC.markDuplicates.opticalDuplicatePixelDistance": null,
-            "bamQC.markDuplicates.picardMaxMemMb": null,
-            "bamQC.markDuplicates.threads": null,
-            "bamQC.markDuplicates.timeout": null,
-            "bamQC.metadata": {
-                "donor": "Xenomorph",
-                "group id": "Weyland-Yutani",
-                "library design": "WY-1001",
-                "tissue origin": "LV-426",
-                "tissue type": "Claw fragment"
-            },
-            "bamQC.outputFileNamePrefix": "test_empty_input",
-            "bamQC.runMosdepth.jobMemory": null,
-            "bamQC.runMosdepth.modules": null,
-            "bamQC.runMosdepth.threads": null,
-            "bamQC.runMosdepth.timeout": null,
-            "bamQC.updateMetadata.jobMemory": null,
-            "bamQC.updateMetadata.modules": null,
-            "bamQC.updateMetadata.threads": null,
-            "bamQC.updateMetadata.timeout": null
-        },
-        "description": "bamQC workflow test",
-        "engineArguments": {
-           "write_to_cache": false,
-           "read_from_cache": false
-        },
-        "id": "bamQC_test_empty_input",
-        "metadata": {
-            "bamQC.result": {
-                "contents": [
-                    {
-                        "outputDirectory": "@SCRATCH@/@DATE@_Workflow_bamQC_bamQC_test_empty_input_@JENKINSID@"
-                    }
-                ],
-                "type": "ALL"
-            }
-        },
-        "validators": [
-            {
-                "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
-                "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.1.1/bamQC_test_empty_input.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.3.0/bamQC_test_targeted.metrics",
                 "type": "script"
             }
         ]
@@ -820,7 +305,7 @@
                 {
                     "bam":{
                         "contents": {
-                        "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_CRE/SWID_15949654_CRE_0002_Pb_R_PE_409_WG_200124_A00469_0077_BHNGLTDSXX_GAGACGAT-TAACCGGT_L002_001.annotated.bam",
+                        "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.bam",
                         "externalIds": [
                             {
                                 "id": "TEST",
@@ -832,7 +317,7 @@
                     },
                     "bamIndex": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_CRE/SWID_15949654_CRE_0002_Pb_R_PE_409_WG_200124_A00469_0077_BHNGLTDSXX_GAGACGAT-TAACCGGT_L002_001.annotated.bam.bai",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/SWID_Test01.annotated.subset.annotated.bam.bai",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -846,7 +331,7 @@
                 {
                     "bam":{
                         "contents": {
-                        "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_with_downsample/neat_5x_EX_hg19_chr21.bam",
+                        "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/neat_Test01.bam",
                         "externalIds": [
                             {
                                 "id": "TEST",
@@ -858,7 +343,7 @@
                     },
                     "bamIndex": {
                         "contents": {
-                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/input_data/bamQC_test_with_downsample/neat_5x_EX_hg19_chr21.bam.bai",
+                            "configuration": "/.mounts/labs/gsi/testdata/bamqc/test_inputs/neat_Test01.bam.bai",
                             "externalIds": [
                                 {
                                     "id": "TEST",
@@ -871,96 +356,30 @@
                 }
             ],
             "bamQC.mode": "call_ready",
-            "bamQC.intervalsToParallelizeByString": "chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM",
-            "bamQC.mergeFiles.cores": null,
-            "bamQC.mergeFiles.modules": null,
-            "bamQC.mergeFiles.suffix": null,
-            "bamQC.mergeFiles.jobMemory": null,
-            "bamQC.mergeFiles.overhead": null,
-            "bamQC.mergeFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.jobMemory": null,
-            "bamQC.mergeSplitByIntervalFiles.overhead": null,
-            "bamQC.mergeSplitByIntervalFiles.suffix": null,
-            "bamQC.mergeSplitByIntervalFiles.cores": null,
-            "bamQC.mergeSplitByIntervalFiles.timeout": null,
-            "bamQC.mergeSplitByIntervalFiles.modules": null,
-            "bamQC.splitStringToArray.cores": null,
-            "bamQC.splitStringToArray.lineSeparator": null,
-            "bamQC.splitStringToArray.jobMemory": null,
-            "bamQC.splitStringToArray.recordSeparator": null,
-            "bamQC.splitStringToArray.timeout": null,
-            "bamQC.splitStringToArray.modules": null,
+            "bamQC.bamQCMetrics.bamQClite": null,
             "bamQC.bamQCMetrics.jobMemory": null,
             "bamQC.bamQCMetrics.modules": null,
-            "bamQC.bamQCMetrics.normalInsertMax": null,
-            "bamQC.bamQCMetrics.refFasta": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19_random.fa",
-            "bamQC.bamQCMetrics.refSizesBed": "/.mounts/labs/gsi/modulator/sw/data/hg19-p13/hg19.chrom.sizes.bed",
-            "bamQC.bamQCMetrics.threads": null,
+            "bamQC.bamQCMetrics.targetBed": null,
             "bamQC.bamQCMetrics.timeout": null,
-            "bamQC.bamQCMetrics.workflowVersion": "4.0.0_TEST",
-            "bamQC.collateResults.jobMemory": null,
-            "bamQC.collateResults.modules": null,
-            "bamQC.collateResults.threads": null,
-            "bamQC.collateResults.timeout": null,
+            "bamQC.bamQCMetrics.workflowVersion": "5.3.0",
             "bamQC.cumulativeDistToHistogram.jobMemory": null,
             "bamQC.cumulativeDistToHistogram.modules": null,
             "bamQC.cumulativeDistToHistogram.threads": null,
             "bamQC.cumulativeDistToHistogram.timeout": null,
-            "bamQC.downsample.downsampleSuffix": null,
-            "bamQC.downsample.jobMemory": null,
-            "bamQC.downsample.modules": null,
-            "bamQC.downsample.randomSeed": null,
-            "bamQC.downsample.threads": null,
-            "bamQC.downsample.timeout": null,
-            "bamQC.downsampleRegion.jobMemory": null,
-            "bamQC.downsampleRegion.modules": null,
-            "bamQC.downsampleRegion.threads": null,
-            "bamQC.downsampleRegion.timeout": null,
-            "bamQC.filter.jobMemory": null,
-            "bamQC.preFilter.minMemory": null,
-            "bamQC.filter.minQuality": null,
-            "bamQC.filter.modules": null,
-            "bamQC.filter.threads": null,
-            "bamQC.filter.timeout": null,
-            "bamQC.getChrCoefficient.memory": null,
-            "bamQC.getChrCoefficient.timeout": null,
-            "bamQC.getChrCoefficient.modules": "samtools/1.14",
-            "bamQC.preFilter.jobMemory": null,
-            "bamQC.preFilter.minMapQuality": null,
-            "bamQC.preFilter.filterFlags": null,
-            "bamQC.preFilter.filterAdditionalParams": null,
-            "bamQC.preFilter.modules": null,
-            "bamQC.preFilter.threads": null,
-            "bamQC.preFilter.timeout": null,
-            "bamQC.preFilter.scaleCoefficient": null,
-            "bamQC.findDownsampleParams.jobMemory": null,
-            "bamQC.findDownsampleParams.minReadsAbsolute": null,
-            "bamQC.findDownsampleParams.minReadsRelative": null,
-            "bamQC.findDownsampleParams.modules": null,
-            "bamQC.findDownsampleParams.preDSMultiplier": null,
-            "bamQC.findDownsampleParams.precision": null,
-            "bamQC.findDownsampleParams.targetReads": 20000,
-            "bamQC.findDownsampleParams.threads": null,
-            "bamQC.findDownsampleParams.timeout": null,
-            "bamQC.findDownsampleParamsMarkDup.baseInterval": null,
-            "bamQC.findDownsampleParamsMarkDup.chromosomes": null,
-            "bamQC.findDownsampleParamsMarkDup.customRegions": null,
-            "bamQC.findDownsampleParamsMarkDup.intervalStart": null,
-            "bamQC.findDownsampleParamsMarkDup.jobMemory": null,
-            "bamQC.findDownsampleParamsMarkDup.modules": null,
-            "bamQC.findDownsampleParamsMarkDup.threads": null,
-            "bamQC.findDownsampleParamsMarkDup.threshold": null,
-            "bamQC.findDownsampleParamsMarkDup.timeout": null,
-            "bamQC.indexBamFile.jobMemory": null,
-            "bamQC.indexBamFile.modules": null,
-            "bamQC.indexBamFile.threads": null,
-            "bamQC.indexBamFile.timeout": null,
+            "bamQC.downsampleToReads": 500000,
+            "bamQC.getUniqueReadsCount.jobMemory": null,
+            "bamQC.getUniqueReadsCount.modules": null,
+            "bamQC.getUniqueReadsCount.timeout": null,
+            "bamQC.markDuplicates.additionalParam": null,
             "bamQC.markDuplicates.jobMemory": null,
             "bamQC.markDuplicates.modules": null,
-            "bamQC.markDuplicates.opticalDuplicatePixelDistance": null,
-            "bamQC.markDuplicates.picardMaxMemMb": null,
+            "bamQC.markDuplicates.samblaster": null,
             "bamQC.markDuplicates.threads": null,
             "bamQC.markDuplicates.timeout": null,
+            "bamQC.mergeReports.bamQCmerger": null,
+            "bamQC.mergeReports.jobMemory": null,
+            "bamQC.mergeReports.modules": null,
+            "bamQC.mergeReports.timeout": null,
             "bamQC.metadata": {
                 "donor": "Xenomorph",
                 "group id": "Weyland-Yutani",
@@ -968,17 +387,20 @@
                 "tissue origin": "LV-426",
                 "tissue type": "Claw fragment"
             },
-            "bamQC.outputFileNamePrefix": "test_multiple_bams_input",
+            "bamQC.outputFileNamePrefix": "CALL_READY",
+            "bamQC.reference": "hg19",
+            "bamQC.runBedtools": null,
+            "bamQC.runBedtoolsIntersect.jobMemory": null,
+            "bamQC.runBedtoolsIntersect.modules": null,
+            "bamQC.runBedtoolsIntersect.timeout": null,
             "bamQC.runMosdepth.jobMemory": null,
             "bamQC.runMosdepth.modules": null,
-            "bamQC.runMosdepth.threads": null,
             "bamQC.runMosdepth.timeout": null,
-            "bamQC.updateMetadata.jobMemory": null,
-            "bamQC.updateMetadata.modules": null,
-            "bamQC.updateMetadata.threads": null,
-            "bamQC.updateMetadata.timeout": null
+            "bamQC.samstats.jobMemory": null,
+            "bamQC.samstats.timeout": null,
+            "bamQC.targetBed": null
         },
-        "description": "bamQC workflow test",
+        "description": "bamQC workflow call ready test",
         "engineArguments": {
            "write_to_cache": false,
            "read_from_cache": false
@@ -998,7 +420,7 @@
             {
                 "metrics_calculate": "@CHECKOUT@/tests/calculate.sh",
                 "metrics_compare": "@CHECKOUT@/tests/compare.sh",
-                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.1.1/bamQC_test_multiple_bams_input.metrics",
+                "output_metrics": "/.mounts/labs/gsi/testdata/bamqc/output_expectation/5.3.0/bamQC_test_multiple_bams_input.metrics",
                 "type": "script"
             }
         ]


### PR DESCRIPTION
In this update we are doing a switch to 'lite' version which primarily relies on external tools to collect the metrics. This version does not perform any filtering, but uses downsampled data to run CIGAR metrics analysis and estimate duplicate read percentage.