### PR TITLE
Added pipefail instructions to three tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.6] - 2026-03-06
+### Added
+- added pipefail instruction where it was appropriate
+
 ## [5.3.5] - 2026-01-10
 ### Changed
 - for reads on target the type changed to String so that large numbers can be handled

--- a/bamQC.wdl
+++ b/bamQC.wdl
@@ -284,6 +284,7 @@ task downsampleBam {
     String bamFileName = basename(bamFile)
 
     command <<<
+    set -euxo pipefail
     samtools head -n ~{downsampleToReads} ~{bamFile} | samtools view -hb > ~{prefix + ".downsampled.bam"}
     >>>
 
@@ -595,6 +596,7 @@ task runBedtoolsIntersect {
     }
 
     command <<<
+    set -euxo pipefail
     if [[ "~{filterCoverage}" == "true" ]]; then
       samtools view  -F 2308 ~{inputBam} -b | bedtools intersect -a - -b ~{targetBed} -u | samtools view -c | perl -pe 'chomp'
     else
@@ -642,6 +644,7 @@ task getUniqueReadsCount {
     }
 
     command <<<
+    set -euxo pipefail
     samtools head -n ~{downsampleToReads} ~{inputBam} | samtools view -F 256 -q 30 -c | perl -pe 'chomp'
     >>>
 
@@ -773,8 +776,6 @@ task mergeReports {
 
     String outputFileName = "~{prefix}.bamQC_results.json"
     command <<<
-    # set -euxo pipefail
-    # export PYTHONPATH=$PYTHONPATH:/.mounts/labs/gsi/testdata/bamqc/scripts/ 
     python3 ~{bamQCmerger} -l ~{sep="," inputs} ~{"-d " + mergedDupmarkingData} ~{"-t " + mergedCoverageData} -o ~{outputFileName}
     >>>
 

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -7,4 +7,4 @@ cd $1
 
 module load jq
 # extract the data for selected metrics
-find . -xtype f -exec  jq '. | with_entries(select(.key | contains("mean","average","reads","total")))' | sed  's/\..*/,/' {} \; 
+find . -xtype f -exec  jq '. | with_entries(select(.key | contains("mean","average","reads","total")))' {} \;  | sed  's/\..*/,/'

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -7,4 +7,4 @@ cd $1
 
 module load jq
 # extract the data for selected metrics
-find . -xtype f -exec  jq '. | with_entries(select(.key | contains("mean","average","reads","total")))' {} \; 
+find . -xtype f -exec  jq '. | with_entries(select(.key | contains("mean","average","reads","total")))' sed  's/\..*//' | sed 's/,//' {} \; 

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -7,4 +7,4 @@ cd $1
 
 module load jq
 # extract the data for selected metrics
-find . -xtype f -exec  jq '. | with_entries(select(.key | contains("mean","average","reads","total")))' sed  's/\..*/,/' {} \; 
+find . -xtype f -exec  jq '. | with_entries(select(.key | contains("mean","average","reads","total")))' | sed  's/\..*/,/' {} \; 

--- a/tests/calculate.sh
+++ b/tests/calculate.sh
@@ -7,4 +7,4 @@ cd $1
 
 module load jq
 # extract the data for selected metrics
-find . -xtype f -exec  jq '. | with_entries(select(.key | contains("mean","average","reads","total")))' sed  's/\..*//' | sed 's/,//' {} \; 
+find . -xtype f -exec  jq '. | with_entries(select(.key | contains("mean","average","reads","total")))' sed  's/\..*/,/' {} \; 


### PR DESCRIPTION
The changes in this pull request aim to address an issue with coverage reported as 0 in some cases. It appears that when workflow runs in production with a highly contested IO some tasks may silently fail (this may be possible since they have piped commands). Added **pipefail** instructions so that we have a  failure  if any of piped commands did  not work as intended.